### PR TITLE
Make distributed system run from shared folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ The amazing Hercules project, taking the stone out of Sisyphus hands! (A real pr
 Prepare for development
 ------------------------
 
+You need to have nfs installed on your machine for the syncing to work properly. On ubuntu install it with:
+
+    sudo apt-get install nfs-common nfs-kernel-server
+
 This project is accompanied by a vagrant file. Once you have Vagrant and VirtualBox set up this means that you should be able to spool up a virtual test system with this command (run from the root of the project):
 
     vagrant up

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -128,8 +128,8 @@ mkdir -p /srv/samplesheet/processning/
 mkdir -p /seqdata/biotank1
 mkdir -p /seqdata/biotank2
 
-chown -r vagrant:vagrant /seqdata/*
-chown -r vagrant:vagrant /srv/samplesheet/processning/
+chown -R vagrant:vagrant /seqdata/*
+chown -R vagrant:vagrant /srv/samplesheet/processning/
 
 mount biotank1:/seqdata/biotank1 /seqdata/biotank1
 mount biotank2:/seqdata/biotank2 /seqdata/biotank2
@@ -199,6 +199,7 @@ Vagrant.configure("2") do |global_config|
             config.vm.box = "chef/centos-6.5"
             config.vm.hostname = "#{name}"
             config.vm.network :private_network, ip: options[:ipaddress]
+            config.vm.synced_folder ".", "/vagrant", type: "nfs"
 
             #VM specifications
             config.vm.provider :virtualbox do |v|


### PR DESCRIPTION
It turns out the the distributed akka system (at least the example one from typesafe) will not run if you are using the default sync between the virtual machine and the host. I have modified Vagrant file to use nfs for syncing instead - and it should now work!

Finding this was not easy, so in the future I expect to be titled the king of debugging!
