### PR TITLE
Moved the picking up of runfolders to...

### DIFF
--- a/src/main/scala/hercules/actors/processingunitwatcher/IlluminaProcessingUnitExecutorActor.scala
+++ b/src/main/scala/hercules/actors/processingunitwatcher/IlluminaProcessingUnitExecutorActor.scala
@@ -8,6 +8,10 @@ import java.io.File
 import hercules.entities.illumina.IlluminaProcessingUnit
 import hercules.config.processingunit.ProcessingUnitConfig
 import hercules.config.processingunit.IlluminaProcessingUnitConfig
+import hercules.entities.illumina.IlluminaProcessingUnit
+import hercules.entities.illumina.IlluminaProcessingUnit
+import hercules.entities.illumina.MiSeqProcessingUnit
+import hercules.entities.illumina.HiSeqProcessingUnit
 
 object IlluminaProcessingUnitExecutorActor {
 
@@ -37,160 +41,6 @@ object IlluminaProcessingUnitExecutorActor {
       customProgamConfigurationRoot,
       defaultProgramConfigurationFile))
   }
-
-  /**
-   * Indicate if the unit is ready to be processed.
-   * Normally this involves checking files on the file system or reading it's
-   * status from a database.
-   *
-   * @param unit The processing unit check
-   * @return if the processing unit is ready to be processed or not.
-   */
-  private def isReadyForProcessing(unit: ProcessingUnit): Boolean = {
-
-    val runfolderPath = new File(unit.uri)
-
-    val filesInRunFolder = runfolderPath.listFiles()
-
-    val hasNoFoundFile =
-      filesInRunFolder.forall(file => {
-        !(file.getName() == "found")
-      })
-
-    val hasRTAComplete =
-      filesInRunFolder.exists(x => x.getName() == "RTAComplete.txt")
-
-    hasNoFoundFile && hasRTAComplete
-  }
-
-  /**
-   * Checks runfolders (IlluminaProcessingUnits) which are ready to be processed
-   * @param runfolderRoot
-   * @param sampleSheetRoot
-   * @param customQCConfigRoot
-   * @param defaultQCConfigFile
-   * @param customProgramConfigRoot
-   * @param defaultProgramConfigFile
-   * @param log
-   * @return A sequence of Illumina processingUnit which are ready to be
-   * processed
-   *
-   */
-  def checkReadyForRunfolders(
-    runfolderRoot: File,
-    sampleSheetRoot: File,
-    customQCConfigRoot: File,
-    defaultQCConfigFile: File,
-    customProgramConfigRoot: File,
-    defaultProgramConfigFile: File,
-    log: akka.event.LoggingAdapter): Seq[IlluminaProcessingUnit] = {
-
-    /**
-     * List all of the subdirectories of dir.
-     */
-    def listSubDirectories(dir: File): Seq[File] = {
-      require(dir.isDirectory(), dir + " was not a directory!")
-      dir.listFiles().filter(p => p.isDirectory())
-    }
-
-    /**
-     * Search from the specified runfolder roots for runfolders which are
-     * ready to be processed.
-     */
-    def searchForRunfolders(): Seq[File] = {
-      // Make sure to only get folders which begin with a date (or six digits
-      // to be precise)
-      listSubDirectories(runfolderRoot).filter(p =>
-        p.getName.matches("""^\d{6}.*$"""))
-    }
-
-    /**
-     * Search for a samplesheet matching the found runfolder.
-     */
-    def searchForSamplesheet(runfolder: File): Option[File] = {
-      val runfolderName = runfolder.getName()
-
-      val samplesheet = sampleSheetRoot.listFiles().
-        find(p => p.getName() == runfolderName + "_samplesheet.csv")
-
-      if (samplesheet.isDefined)
-        log.info("Found matching samplesheet for: " + runfolder.getName())
-      else
-        log.info("Did not find matching samplesheet for: " + runfolder.getName())
-
-      samplesheet
-    }
-
-    /**
-     * Add a hidden .found file, in the runfolder.
-     */
-    def markAsFound(runfolder: File): Boolean = {
-      log.info("Marking: " + runfolder.getName() + " as found.")
-      new File(runfolder + "/found").createNewFile()
-    }
-
-    /**
-     * Gets a special qc config if there is one. If there is not returns the
-     * default one based on the type of run.
-     *
-     * Right now we use Sisyphus and than always wants the same file,
-     * so there is really only on type of default file to get.
-     *
-     * @param runfolder The runfolder to get the quality control definition file for
-     * @return the QC control config file or None
-     */
-    def getQCConfig(runfolder: File): Option[File] = {
-      val customFile =
-        customQCConfigRoot.listFiles().
-          find(qcFile =>
-            qcFile.getName().startsWith(runfolder.getName() + "_qc.xml"))
-
-      if (customFile.isDefined)
-        customFile
-      else {
-        Some(defaultQCConfigFile)
-      }
-    }
-
-    /**
-     * Gets a special program config if there is one. If there is not returns the
-     * default one based on the type of run.
-     *
-     * Right now we use Sisyphus and than always wants the same file,
-     * so there is really only on type of default file to get.
-     *
-     * @param runfolder The runfolder to get the quality control definition file for
-     * @return the program control config file or None
-     */
-    def getProgramConfig(runfolder: File): Option[File] = {
-      val customFile =
-        customProgramConfigRoot.listFiles().
-          find(programFile =>
-            programFile.getName().startsWith(runfolder.getName() + "_sisyphus.yml"))
-
-      if (customFile.isDefined)
-        customFile
-      else {
-        Some(defaultProgramConfigFile)
-      }
-    }
-
-    for {
-      runfolder <- searchForRunfolders()
-      samplesheet <- searchForSamplesheet(runfolder)
-      qcConfig <- getQCConfig(runfolder)
-      programConfig <- getProgramConfig(runfolder)
-      illuminaProcessingUnit <- {
-        val unitConfig =
-          new IlluminaProcessingUnitConfig(samplesheet, qcConfig, Some(programConfig))
-        Some(new IlluminaProcessingUnit(unitConfig, runfolder.toURI()))
-      }
-      if isReadyForProcessing(illuminaProcessingUnit)
-    } yield {
-      illuminaProcessingUnit
-    }
-  }
-
 }
 
 class IlluminaProcessingUnitExecutorActor(
@@ -201,15 +51,16 @@ class IlluminaProcessingUnitExecutorActor(
     val programConfigPath: String,
     val defaultProgramConfigFile: String) extends HerculesActor with ProcessingUnitWatcherActor {
 
-//  val runfolders = IlluminaProcessingUnitExecutorActor.
-//    checkReadyForRunfolders(
-//      new File(runfolderRootPath),
-//      new File(samplesheetPath),
-//      new File(qcControlConfigPath),
-//      new File(defaultQCConfigFile),
-//      new File(programConfigPath),
-//      new File(defaultProgramConfigFile),
-//      log)
+  //@TODO to pick up the processing units, us the function.
+  // It will delagate and pick up the correct sub type.
+  //  val result = IlluminaProcessingUnit.checkForReadyProcessingUnits(
+  //    new File(runfolderRootPath),
+  //    new File(samplesheetPath),
+  //    new File(qcControlConfigPath),
+  //    new File(defaultQCConfigFile),
+  //    new File(programConfigPath),
+  //    new File(defaultProgramConfigFile),
+  //    log)
 
   def receive = ???
 

--- a/src/main/scala/hercules/entities/illumina/HiSeqProcessingUnit.scala
+++ b/src/main/scala/hercules/entities/illumina/HiSeqProcessingUnit.scala
@@ -7,7 +7,7 @@ import hercules.config.processingunit.ProcessingUnitConfig
 /**
  * Represent a HiSeq runfolder
  */
-class HiSeqProcessingUnit(
+case class HiSeqProcessingUnit(
   processingUnitConfig: ProcessingUnitConfig,
   uri: URI)
     extends IlluminaProcessingUnit(processingUnitConfig, uri) {

--- a/src/main/scala/hercules/entities/illumina/IlluminaProcessingUnit.scala
+++ b/src/main/scala/hercules/entities/illumina/IlluminaProcessingUnit.scala
@@ -4,12 +4,188 @@ import java.io.File
 import java.net.URI
 import hercules.entities.ProcessingUnit
 import hercules.config.processingunit.ProcessingUnitConfig
+import hercules.config.processingunit.IlluminaProcessingUnitConfig
+
+object IlluminaProcessingUnit {
+  /**
+   * Indicate if the unit is ready to be processed.
+   * Normally this involves checking files on the file system or reading it's
+   * status from a database.
+   *
+   * @param unit The processing unit check
+   * @return if the processing unit is ready to be processed or not.
+   */
+  private def isReadyForProcessing(unit: ProcessingUnit): Boolean = {
+
+    val runfolderPath = new File(unit.uri)
+
+    val filesInRunFolder = runfolderPath.listFiles()
+
+    val hasNoFoundFile =
+      filesInRunFolder.forall(file => {
+        !(file.getName() == "found")
+      })
+
+    val hasRTAComplete =
+      filesInRunFolder.exists(x => x.getName() == "RTAComplete.txt")
+
+    hasNoFoundFile && hasRTAComplete
+  }
+
+  /**
+   * Checks runfolders (IlluminaProcessingUnits) which are ready to be processed
+   * It will delagate and return the correct sub type (MiSeq, or HiSeq) processing unit.
+   * @param runfolderRoot
+   * @param sampleSheetRoot
+   * @param customQCConfigRoot
+   * @param defaultQCConfigFile
+   * @param customProgramConfigRoot
+   * @param defaultProgramConfigFile
+   * @param log
+   * @return A sequence of Illumina processingUnit which are ready to be
+   * processed
+   *
+   */
+  def checkForReadyProcessingUnits(
+    runfolderRoot: File, 
+    sampleSheetRoot: File, 
+    customQCConfigRoot: File, 
+    defaultQCConfigFile: File, 
+    customProgramConfigRoot: File, 
+    defaultProgramConfigFile: File, 
+    log: akka.event.LoggingAdapter): Seq[IlluminaProcessingUnit] = {
+
+    /**
+     * List all of the subdirectories of dir.
+     */
+    def listSubDirectories(dir: File): Seq[File] = {
+      require(dir.isDirectory(), dir + " was not a directory!")
+      dir.listFiles().filter(p => p.isDirectory())
+    }
+
+    /**
+     * Search from the specified runfolder roots for runfolders which are
+     * ready to be processed.
+     */
+    def searchForRunfolders(): Seq[File] = {
+      // Make sure to only get folders which begin with a date (or six digits
+      // to be precise)
+      listSubDirectories(runfolderRoot).filter(p =>
+        p.getName.matches("""^\d{6}.*$"""))
+    }
+
+    /**
+     * Search for a samplesheet matching the found runfolder.
+     */
+    def searchForSamplesheet(runfolder: File): Option[File] = {
+      val runfolderName = runfolder.getName()
+
+      val samplesheet = sampleSheetRoot.listFiles().
+        find(p => p.getName() == runfolderName + "_samplesheet.csv")
+
+      if (samplesheet.isDefined)
+        log.info("Found matching samplesheet for: " + runfolder.getName())
+      else
+        log.info("Did not find matching samplesheet for: " + runfolder.getName())
+
+      samplesheet
+    }
+
+    /**
+     * Add a hidden .found file, in the runfolder.
+     */
+    def markAsFound(runfolder: File): Boolean = {
+      log.info("Marking: " + runfolder.getName() + " as found.")
+      (new File(runfolder + "/found")).createNewFile()
+    }
+
+    /**
+     * Gets a special qc config if there is one. If there is not returns the
+     * default one based on the type of run.
+     *
+     * Right now we use Sisyphus and than always wants the same file,
+     * so there is really only on type of default file to get.
+     *
+     * @param runfolder The runfolder to get the quality control definition file for
+     * @return the QC control config file or None
+     */
+    def getQCConfig(runfolder: File): Option[File] = {
+      val customFile =
+        customQCConfigRoot.listFiles().
+          find(qcFile =>
+            qcFile.getName().startsWith(runfolder.getName() + "_qc.xml"))
+
+      if (customFile.isDefined)
+        customFile
+      else {
+        Some(defaultQCConfigFile)
+      }
+    }
+
+    /**
+     * Gets a special program config if there is one. If there is not returns the
+     * default one based on the type of run.
+     *
+     * Right now we use Sisyphus and than always wants the same file,
+     * so there is really only on type of default file to get.
+     *
+     * @param runfolder The runfolder to get the quality control definition file for
+     * @return the program control config file or None
+     */
+    def getProgramConfig(runfolder: File): Option[File] = {
+      val customFile =
+        customProgramConfigRoot.listFiles().
+          find(programFile =>
+            programFile.getName().startsWith(runfolder.getName() + "_sisyphus.yml"))
+
+      if (customFile.isDefined)
+        customFile
+      else {
+        Some(defaultProgramConfigFile)
+      }
+    }
+
+    /**
+     * Based on the parameters found. Construct a MiSeq or a HiSeq processing
+     * unit
+     * @param runfolder
+     * @param samplesheet
+     * @param qcConfig
+     * @param programConfig
+     * @return A ProcessingUnit option
+     */
+    def constructCorrectProcessingUnitType(
+      runfolder: File, 
+      samplesheet: File, 
+      qcConfig: File, 
+      programConfig: File): Option[IlluminaProcessingUnit] = {
+      val unitConfig =
+        new IlluminaProcessingUnitConfig(samplesheet, qcConfig, Some(programConfig))
+
+      //@TODO Some nicer solution for picking up if it's a HiSeq or MiSeq
+      if (runfolder.getAbsolutePath().contains("MiSeq"))
+        Some(new MiSeqProcessingUnit(unitConfig, runfolder.toURI()))
+      else
+        Some(new HiSeqProcessingUnit(unitConfig, runfolder.toURI()))
+    }
+
+    for {
+      runfolder <- searchForRunfolders()
+      samplesheet <- searchForSamplesheet(runfolder)
+      qcConfig <- getQCConfig(runfolder)
+      programConfig <- getProgramConfig(runfolder)
+      illuminaProcessingUnit <- constructCorrectProcessingUnitType(runfolder, samplesheet, qcConfig, programConfig)
+      if isReadyForProcessing(illuminaProcessingUnit)
+    } yield {
+      illuminaProcessingUnit
+    }
+  }
+}
 
 /**
  * Provides a base for representing a Illumina runfolder.
  */
-case class IlluminaProcessingUnit(
-  processingUnitConfig: ProcessingUnitConfig,
-  uri: URI) extends ProcessingUnit {
-
+abstract class IlluminaProcessingUnit(
+    processingUnitConfig: ProcessingUnitConfig,
+    uri: URI) extends ProcessingUnit {
 }


### PR DESCRIPTION
... the processing units themselves. Feels better to keep them there. Also I think it will make it easier to test if the actors contains as little logic as possible. This will mean that you can test the behavior of picking up the runfolder without needing to start a actor system.
