### PR TITLE
Cleaned trait signature in ProcessingUnitFetcher

### DIFF
--- a/src/main/scala/hercules/entities/ProcessingUnitFetcher.scala
+++ b/src/main/scala/hercules/entities/ProcessingUnitFetcher.scala
@@ -3,8 +3,11 @@ package hercules.entities
 import hercules.config.processingunit.ProcessingUnitConfig
 import hercules.config.processingunit.ProcessingUnitFetcherConfig
 
-trait ProcessingUnitFetcher[A <: ProcessingUnitFetcherConfig, B <: ProcessingUnit] {
-  def isReadyForProcessing(unit: B): Boolean
+trait ProcessingUnitFetcher {
+  type FetherConfigType <: ProcessingUnitFetcherConfig
+  type ProcessingUnitType <: ProcessingUnit
+
+  def isReadyForProcessing(unit: ProcessingUnitType): Boolean
   def checkForReadyProcessingUnits(
-    config: A): Seq[B]
+    config: FetherConfigType): Seq[ProcessingUnitType]
 }

--- a/src/main/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcher.scala
+++ b/src/main/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcher.scala
@@ -19,7 +19,10 @@ object IlluminaProcessingUnitFetcher {
 
 }
 
-class IlluminaProcessingUnitFetcher() extends ProcessingUnitFetcher[IlluminaProcessingUnitFetcherConfig, IlluminaProcessingUnit] {
+class IlluminaProcessingUnitFetcher() extends ProcessingUnitFetcher {
+
+  type FetherConfigType = IlluminaProcessingUnitFetcherConfig
+  type ProcessingUnitType = IlluminaProcessingUnit
 
   /**
    * Indicate if the unit is ready to be processed.


### PR DESCRIPTION
I think using types is cleared, and then the implementing class can define the types, rather than having a very complicated type signature.
