### PR TITLE
Improving tracibility

### DIFF
--- a/src/main/scala/hercules/actors/HerculesActor.scala
+++ b/src/main/scala/hercules/actors/HerculesActor.scala
@@ -3,10 +3,11 @@ package hercules.actors
 import akka.actor.Actor
 import akka.actor.ActorLogging
 import hercules.actors.notifiers.NotifierManager
+import hercules.utils.VersionUtils
 
 /**
  *  The base trait for all Hercules actors. All actors (which are not
- *  spinned up in a very local context, e.g. annonymous actors) should extend
+ *  spun up in a very local context, e.g. anonymous actors) should extend
  *  this class. Another exception to this is the notification actors should not
  *  extend this trait, as they are attached to it via the notice field.
  */
@@ -19,4 +20,10 @@ trait HerculesActor extends Actor with ActorLogging {
    *  based on the message level what to do with it (i.e. send emails, etc).
    */
   val notice = NotifierManager(context.system)
+
+  /**
+   * This will make sure that the log gets an entry with the
+   * version of hercules run, every time a HerculesActor is started.
+   */
+  log.info("Hercules version: " + VersionUtils.herculesVersion)
 }

--- a/src/main/scala/hercules/entities/illumina/IlluminaProcessingUnit.scala
+++ b/src/main/scala/hercules/entities/illumina/IlluminaProcessingUnit.scala
@@ -1,10 +1,11 @@
 package hercules.entities.illumina
 
-import java.io.File
+import java.io.{ PrintWriter, File }
 import java.net.URI
 
 import hercules.config.processingunit.IlluminaProcessingUnitConfig
 import hercules.entities.ProcessingUnit
+import hercules.utils.VersionUtils
 
 /**
  * Provides a base for representing a Illumina runfolder.
@@ -32,8 +33,19 @@ trait IlluminaProcessingUnit extends ProcessingUnit {
 
   /**
    * Marking as found means creating the indicator file.
+   * Will propagate any exceptions thrown while trying to create
+   * the found file.
    */
-  def markAsFound: Boolean = indicatorFile.createNewFile
+  def markAsFound: Boolean = {
+    try {
+      val printWriter = new PrintWriter(indicatorFile)
+      printWriter.println("The version of hercules was: " + VersionUtils.herculesVersion)
+      printWriter.close()
+      true
+    } catch {
+      case e: Exception => throw e
+    }
+  }
 
   /**
    * Marking as not found means removing the indicator file.

--- a/src/main/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcher.scala
+++ b/src/main/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcher.scala
@@ -290,8 +290,6 @@ class IlluminaProcessingUnitFetcher() extends ProcessingUnitFetcher {
       qcConfig: File,
       programConfig: File): Option[IlluminaProcessingUnit] = {
 
-      import hercules.utils.Conversions.file2URI
-
       val unitConfig =
         new IlluminaProcessingUnitConfig(samplesheet, qcConfig, Some(programConfig))
 

--- a/src/main/scala/hercules/utils/VersionUtils.scala
+++ b/src/main/scala/hercules/utils/VersionUtils.scala
@@ -1,0 +1,22 @@
+package hercules.utils
+
+/**
+ *
+ *
+ *
+ * Created by johda411 on 2015-03-09.
+ */
+object VersionUtils {
+
+  /**
+   * Report back the Hercules version as set in the manifest file
+   */
+  lazy val herculesVersion: String = {
+    val versionFromJar = this.getClass.getPackage.getImplementationVersion
+    if (versionFromJar == null)
+      "development version (this should not be seen in production mode)"
+    else
+      versionFromJar
+  }
+
+}


### PR DESCRIPTION
I've added code which will output the Hercules version in the log everytime actor is starting. In addition to this the "found" file created when Hercules finds a new runfolder will contain a note on what Hercules version was used to process it.

All of this info is now pulled from the manifest file, so it will not be available e.g. when running through sbt, but I decided that this was good enough, since this data is only critical when going to production anyways.