### PR TITLE
Triggering the NGI pipeline

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -50,6 +50,13 @@ notifications {
     slack_user = "Hercules"
     icon_emoji = ":ghost:"
   }
+  ngipipeline {
+    channels = ["progress"]
+    retry_interval = 60
+    num_retries = 2
+    host = localhost
+    port = 1337
+  }
 }
 
 #------------------------------------------------

--- a/src/main/scala/hercules/actors/masters/SisyphusMasterActor.scala
+++ b/src/main/scala/hercules/actors/masters/SisyphusMasterActor.scala
@@ -177,13 +177,12 @@ class SisyphusMasterActor(config: MasterActorConfig) extends PersistentActor wit
 
     demuxMessage match {
 
-      case FinishedDemultiplexingProcessingUnitMessage(unit) => {
-        //@TODO Later more behaviour downstream of demultiplexing should
-        // be added here!
-        log.debug("Noted that " + unit.name + " has finished " +
+      case message: FinishedDemultiplexingProcessingUnitMessage => {
+        //@TODO Later more behaviour downstream of demultiplexing should be added here!
+        log.debug("Noted that " + message.unit.name + " has finished " +
           " demultiplexing. I'll remove it from the messagesInProcessing set.")
-        notice.progress(unit.name + " has finished processing!")
-        self ! RemoveFromMessagesInProcessing(state.findStateOfUnit(Some(unit.name)).messagesInProcessing.headOption)
+        notice.progress(message.unit.name + " has finished processing!", originalMessage = message)
+        self ! RemoveFromMessagesInProcessing(state.findStateOfUnit(Some(message.unit.name)).messagesInProcessing.headOption)
       }
 
       case message: FailedDemultiplexingProcessingUnitMessage => {

--- a/src/main/scala/hercules/actors/notifiers/NotifierActor.scala
+++ b/src/main/scala/hercules/actors/notifiers/NotifierActor.scala
@@ -27,6 +27,15 @@ trait NotifierActor extends Actor with ActorLogging {
   def notifierConfig: NotificationConfig
 
   /**
+   * Hook for adding behaviour to filter out some messages from the channel
+   * while retaining others. By default it will not filter out messages.
+   * Override in implementing class to implement filtering behaviour.
+   * @param notificationMessage to check for inclusion
+   * @return true if the messages is to be kept.
+   */
+  def preFilterChannel(notificationMessage: SendNotificationUnitMessage): Boolean = true
+
+  /**
    * Check if this particular notifier is subscribing to the channel
    * on which the message is being sent, and if so forward it to the
    * executor.
@@ -55,7 +64,7 @@ trait NotifierActor extends Actor with ActorLogging {
     }
 
     case notificationMessage: SendNotificationUnitMessage =>
-      if (notifierConfig.channels.contains(notificationMessage.unit.channel)) {
+      if (notifierConfig.channels.contains(notificationMessage.unit.channel) && preFilterChannel(notificationMessage)) {
         log.debug("Found message on subscription channel will forward it " +
           "to the executor.")
         // Pass the message to the executor

--- a/src/main/scala/hercules/actors/notifiers/rest/ngipipeline/NGIPipelineNotifierActor.scala
+++ b/src/main/scala/hercules/actors/notifiers/rest/ngipipeline/NGIPipelineNotifierActor.scala
@@ -1,0 +1,46 @@
+package hercules.actors.notifiers.rest.ngipipeline
+
+import akka.actor.{ Props, ActorRef, ActorSystem }
+import hercules.actors.notifiers.NotifierActor
+import hercules.config.notification.{ NGIPipelineNotificationConfig, NotificationConfig }
+import hercules.protocols.HerculesMainProtocol.{ FinishedDemultiplexingProcessingUnitMessage, SendNotificationUnitMessage }
+
+/**
+ * A notifier actor to communicate with the ngi pipline. Specifically made to
+ * automatically trigger analysis for WGS data.
+ *
+ * Created by johda411 on 2015-03-20.
+ */
+object NGIPipelineNotifierActor {
+
+  /**
+   * We only want to send on messages to the executor which are related to
+   * starting finished demultiplexing a runfolder. (Since that means that we can
+   * proceed to start the NGI pipeline).
+   * @param notificationMessage to check for inclusion
+   * @return true if the messages is to be kept.
+   */
+  def notifierActorChannelPreFilter(notificationMessage: SendNotificationUnitMessage): Boolean = {
+    val originalMsg = notificationMessage.unit.originalMessage
+    originalMsg.isDefined && originalMsg.get.isInstanceOf[FinishedDemultiplexingProcessingUnitMessage]
+  }
+
+  /**
+   * @param system to create actor in.
+   * @param config to use (will get it's info from application.conf be default)
+   * @return a reference to an instance of NGIPipelineNotification.
+   */
+  def apply(implicit system: ActorSystem, config: NGIPipelineNotificationConfig = NGIPipelineNotificationConfig()): ActorRef = {
+
+    def ngiNotifierActor = new NotifierActor {
+      override def executor: ActorRef = system.actorOf(NGIPipelineNotifierExecutor.props(config))
+      override def notifierConfig: NotificationConfig = config
+      override def preFilterChannel(notificationMessage: SendNotificationUnitMessage): Boolean = {
+        notifierActorChannelPreFilter(notificationMessage)
+      }
+    }
+
+    system.actorOf(Props(ngiNotifierActor))
+  }
+
+}

--- a/src/main/scala/hercules/actors/notifiers/rest/ngipipeline/NGIPipelineNotifierExecutor.scala
+++ b/src/main/scala/hercules/actors/notifiers/rest/ngipipeline/NGIPipelineNotifierExecutor.scala
@@ -18,7 +18,7 @@ import scalaj.http.{ HttpResponse, Http }
 object NGIPipelineNotifierExecutor {
 
   /**
-   * Used to create a SlackNotifierExecutor actor instance.
+   * Used to create a NGIPipelineNotifierExecutor actor instance.
    * @param config to use
    * @return a Props for the SlackNotifierExecutor
    */

--- a/src/main/scala/hercules/actors/notifiers/rest/ngipipeline/NGIPipelineNotifierExecutor.scala
+++ b/src/main/scala/hercules/actors/notifiers/rest/ngipipeline/NGIPipelineNotifierExecutor.scala
@@ -1,0 +1,77 @@
+package hercules.actors.notifiers.rest.ngipipeline
+
+import akka.actor.{ ActorLogging, Actor, Props }
+import hercules.actors.notifiers.NotificationExecutor
+import hercules.actors.notifiers.rest.{ RestClient, RestNotifierExecutor }
+import hercules.config.notification.NGIPipelineNotificationConfig
+import hercules.protocols.HerculesMainProtocol.{ FinishedDemultiplexingProcessingUnitMessage, NotificationUnitMessage }
+
+import scala.concurrent.Future
+import scalaj.http.{ HttpResponse, Http }
+
+/**
+ *
+ * The executor which communicates with the NGI pipeline
+ *
+ * Created by johda411 on 2015-03-20.
+ */
+object NGIPipelineNotifierExecutor {
+
+  /**
+   * Used to create a SlackNotifierExecutor actor instance.
+   * @param config to use
+   * @return a Props for the SlackNotifierExecutor
+   */
+  def props(config: NGIPipelineNotificationConfig): Props = {
+    Props(new NGIPipelineNotifierExecutor(config))
+  }
+
+}
+
+/**
+ *
+ * The executor which communicates with the NGI pipeline - this will only work with
+ * FinishedDemultiplexingProcessingUnitMessage.
+ *
+ * TODO Implement mechanism to check if this is a runfolder that should actually be
+ * processed by the NGI pipeline
+ *
+ *
+ * Created by johda411 on 2015-03-20.
+ */
+class NGIPipelineNotifierExecutor(config: NGIPipelineNotificationConfig) extends NotificationExecutor with RestNotifierExecutor with RestClient {
+
+  this: Actor with ActorLogging with RestClient =>
+
+  private def triggerNGIPipeline(runfolder: String): HttpResponse[String] = {
+    Http(s"http://${config.host}:${config.port}/flowcell_analysis/$runfolder").execute()
+  }
+
+  /**
+   * Any messages received will be end into the Slack channel.
+   * @param message to be sent to Slack
+   * @return a future containing info on if the http request was successful or not.
+   */
+  override def mapMessageToEndPoint(message: NotificationUnitMessage): Future[HttpResponse[String]] = {
+
+    import context.dispatcher
+
+    val requestResponse: Future[HttpResponse[String]] =
+      Future {
+
+        val finishedMessage = message.unit.originalMessage.getOrElse(
+          throw new IllegalArgumentException("If this exception is thrown it means that the pre-filtering " +
+            "of the message channel in the NGPPipelineNotfierActor has not worked as expected. The message was: " +
+            message))
+
+        // Suppressing compiler warnings here since anything but a FinishedDemultiplexingProcessingUnitMessage
+        // should be dropped here.
+        (finishedMessage: @unchecked) match {
+          case FinishedDemultiplexingProcessingUnitMessage(unit) => triggerNGIPipeline(unit.name)
+        }
+      }
+
+    requestResponse
+  }
+
+}

--- a/src/main/scala/hercules/config/notification/NGIPipelineNotificationConfig.scala
+++ b/src/main/scala/hercules/config/notification/NGIPipelineNotificationConfig.scala
@@ -1,0 +1,40 @@
+package hercules.config.notification
+
+import com.typesafe.config.{ ConfigFactory, Config }
+import hercules.protocols.NotificationChannelProtocol._
+
+import scala.collection.JavaConversions._
+
+/**
+ * Factory functions to create default and custom NGIPipelineNotificationConfigs,
+ * where the default configurations are picked up from the application.conf
+ * Created by johda411 on 2015-03-20.
+ */
+object NGIPipelineNotificationConfig {
+
+  def apply(): NGIPipelineNotificationConfig = {
+    getNGIPipelineNotificationConfig(ConfigFactory.load().getConfig("notifications.ngipipeline"))
+  }
+
+  def getNGIPipelineNotificationConfig(conf: Config): NGIPipelineNotificationConfig = {
+    new NGIPipelineNotificationConfig(
+      channels = asScalaBuffer(conf.getStringList("channels")).toSeq.map(stringToChannel),
+      retryInterval = conf.getInt("num_retries"),
+      numRetries = conf.getInt("retry_interval"),
+      host = conf.getString("host"),
+      port = conf.getInt("port"))
+  }
+
+}
+
+/**
+ * A configuration for communicating with the NGI pipline
+ * @param channels the Notifications channels to use.
+ * @param retryInterval seconds to wait between retries
+ * @param numRetries to do before giving up on sending the notification
+ */
+class NGIPipelineNotificationConfig(override val channels: Seq[NotificationChannel],
+                                    override val retryInterval: Int,
+                                    override val numRetries: Int,
+                                    val host: String,
+                                    val port: Int) extends NotificationConfig() {}

--- a/src/main/scala/hercules/config/notification/NotificationConfig.scala
+++ b/src/main/scala/hercules/config/notification/NotificationConfig.scala
@@ -5,6 +5,8 @@ import hercules.protocols.NotificationChannelProtocol._
 /**
  * Base class for configuring a notification
  * @param channels the Notifications channels to use.
+ * @param numRetries to do before giving up on sending the notification
+ * @param retryInterval seconds to wait between retries
  */
 abstract class NotificationConfig {
   val channels: Seq[NotificationChannel]

--- a/src/main/scala/hercules/entities/notification/NotificationUnit.scala
+++ b/src/main/scala/hercules/entities/notification/NotificationUnit.scala
@@ -1,5 +1,6 @@
 package hercules.entities.notification
 
+import hercules.protocols.HerculesMainProtocol.HerculesMessage
 import hercules.protocols.NotificationChannelProtocol._
 
 /**
@@ -8,8 +9,10 @@ import hercules.protocols.NotificationChannelProtocol._
  * @param message to send
  * @param channel to send it on.
  * @param attempts this many attempts have been made at sending this notification
+ * @param originalMessage optionally add the original message (can be used to trigger downstream behaviour.
  */
 class NotificationUnit(
   val message: String,
   val channel: NotificationChannel,
-  val attempts: Int = 0) {}
+  val attempts: Int = 0,
+  val originalMessage: Option[HerculesMessage] = None) {}

--- a/src/test/scala/hercules/actors/notifiers/rest/ngipipeline/NGIPipelineNotifierActorTest.scala
+++ b/src/test/scala/hercules/actors/notifiers/rest/ngipipeline/NGIPipelineNotifierActorTest.scala
@@ -1,0 +1,62 @@
+package hercules.actors.notifiers.rest.ngipipeline
+
+import java.io.File
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import hercules.config.processingunit.IlluminaProcessingUnitConfig
+import hercules.entities.illumina.{ HiSeqProcessingUnit, IlluminaProcessingUnit }
+import hercules.entities.notification.NotificationUnit
+import hercules.protocols.HerculesMainProtocol.{ StartDemultiplexingProcessingUnitMessage, FinishedDemultiplexingProcessingUnitMessage, SendNotificationUnitMessage }
+import hercules.protocols.NotificationChannelProtocol
+import org.scalatest.{ FlatSpecLike, FunSuite }
+
+/**
+ * Tests for the NGIPiperlineNotifierActor
+ * Created by johda411 on 2015-03-20.
+ */
+class NGIPipelineNotifierActorTest extends TestKit(ActorSystem("NGIPipelineNotifierActorTestSystem"))
+    with FlatSpecLike {
+
+  "A NGIPipelineNotifierActor" should "start up without throwing exceptions" in {
+    val actor = NGIPipelineNotifierActor(system)
+  }
+
+  it should "pre-filter keep if original message was a FinishedDemultiplexingProcessingUnitMessage and filter out other messages" in {
+
+    val runfolder = new File("runfolder1")
+    val processingUnit: IlluminaProcessingUnit =
+      new HiSeqProcessingUnit(
+        new IlluminaProcessingUnitConfig(
+          new File("Samplesheet1"),
+          new File("DefaultQC"),
+          Some(new File("DefaultProg"))),
+        runfolder.toURI())
+
+    val finishedDemultiplexingProcessingUnitMessage = FinishedDemultiplexingProcessingUnitMessage(unit = processingUnit)
+    val startDemultiplexingProcessingUnitMessage = StartDemultiplexingProcessingUnitMessage(unit = processingUnit)
+
+    val keepThis =
+      SendNotificationUnitMessage(
+        new NotificationUnit(
+          message = "test",
+          originalMessage = Some(finishedDemultiplexingProcessingUnitMessage),
+          channel = NotificationChannelProtocol.Critical))
+
+    val filterThis = SendNotificationUnitMessage(
+      new NotificationUnit(
+        message = "test",
+        originalMessage = Some(startDemultiplexingProcessingUnitMessage),
+        channel = NotificationChannelProtocol.Critical))
+
+    val alsoFilterIfThereIsNoOriginalMessage = SendNotificationUnitMessage(
+      new NotificationUnit(
+        message = "test",
+        channel = NotificationChannelProtocol.Critical))
+
+    assert(NGIPipelineNotifierActor.notifierActorChannelPreFilter(keepThis) === true)
+    assert(NGIPipelineNotifierActor.notifierActorChannelPreFilter(filterThis) === false)
+    assert(NGIPipelineNotifierActor.notifierActorChannelPreFilter(alsoFilterIfThereIsNoOriginalMessage) === false)
+  }
+
+}

--- a/src/test/scala/hercules/actors/notifiers/rest/ngipipeline/NGIPipelineNotifierExecutorTest.scala
+++ b/src/test/scala/hercules/actors/notifiers/rest/ngipipeline/NGIPipelineNotifierExecutorTest.scala
@@ -1,0 +1,81 @@
+package hercules.actors.notifiers.rest.ngipipeline
+
+import java.io.File
+
+import akka.actor.ActorSystem
+import akka.testkit.{ ImplicitSender, TestKit }
+import com.netaporter.precanned.dsl.fancy._
+import hercules.config.notification.NGIPipelineNotificationConfig
+import hercules.config.processingunit.IlluminaProcessingUnitConfig
+import hercules.entities.illumina.{ HiSeqProcessingUnit, IlluminaProcessingUnit }
+import hercules.entities.notification.NotificationUnit
+import hercules.protocols.HerculesMainProtocol.{ FailedNotificationUnitMessage, SentNotificationUnitMessage, FinishedDemultiplexingProcessingUnitMessage, SendNotificationUnitMessage }
+import hercules.protocols.NotificationChannelProtocol
+import org.scalatest.{ BeforeAndAfterAll, Matchers, BeforeAndAfter, FlatSpecLike }
+import spray.http.StatusCodes
+
+/**
+ * Created by johda411 on 2015-03-20.
+ */
+class NGIPipelineNotifierExecutorTest extends TestKit(ActorSystem("SlackNotifierExecutorActorTestSystem"))
+    with ImplicitSender
+    with FlatSpecLike
+    with BeforeAndAfter
+    with BeforeAndAfterAll
+    with Matchers {
+
+  val mockBindingPort = 8766
+  val mockNgiPipeline = httpServerMock(system).bind(mockBindingPort).block
+
+  // Make sure expectations as cleared between tests.
+  after { mockNgiPipeline.clearExpectations }
+  override def afterAll() { system.shutdown() }
+
+  val conf = new NGIPipelineNotificationConfig(
+    channels = Seq(NotificationChannelProtocol.Progress),
+    retryInterval = 1,
+    numRetries = 3,
+    host = "localhost",
+    port = mockBindingPort)
+
+  val runfolder = new File("runfolder1")
+  val processingUnit: IlluminaProcessingUnit =
+    new HiSeqProcessingUnit(
+      new IlluminaProcessingUnitConfig(
+        new File("Samplesheet1"),
+        new File("DefaultQC"),
+        Some(new File("DefaultProg"))),
+      runfolder.toURI())
+
+  val finishedDemultiplexingProcessingUnitMessage = FinishedDemultiplexingProcessingUnitMessage(unit = processingUnit)
+
+  val unit =
+    new NotificationUnit(
+      message = "test message",
+      channel = NotificationChannelProtocol.Progress,
+      originalMessage = Some(finishedDemultiplexingProcessingUnitMessage))
+  val progressMessage = new SendNotificationUnitMessage(unit)
+
+  val actor = system.actorOf(NGIPipelineNotifierExecutor.props(conf))
+
+  "A NGIPipelineNotifierExecutor" should "trigger the NGI pipline when there is a finished demultiplexing message." in {
+
+    actor ! progressMessage
+    mockNgiPipeline expect path(s"/flowcell_analysis/${runfolder.getName()}") and respond using status(StatusCodes.OK) end ()
+    expectMsg(SentNotificationUnitMessage(unit))
+
+  }
+
+  it should "throw and exception and exit gracefully if it's sent a message without info on the original message" in {
+
+    val unit =
+      new NotificationUnit(
+        message = "test message",
+        channel = NotificationChannelProtocol.Progress)
+    val progressMessage = new SendNotificationUnitMessage(unit)
+    actor ! progressMessage
+    // Don't care about the reason in the message for now...
+    expectMsgType[FailedNotificationUnitMessage]
+  }
+
+}

--- a/src/test/scala/hercules/actors/notifiers/rest/slack/SlackNotifierExecutorTest.scala
+++ b/src/test/scala/hercules/actors/notifiers/rest/slack/SlackNotifierExecutorTest.scala
@@ -6,18 +6,20 @@ import hercules.config.notification.SlackNotificationConfig
 import hercules.entities.notification.NotificationUnit
 import hercules.protocols.HerculesMainProtocol.{ FailedNotificationUnitMessage, SentNotificationUnitMessage, SendNotificationUnitMessage }
 import hercules.protocols.NotificationChannelProtocol
-import org.scalatest.{ BeforeAndAfter, Matchers, FlatSpecLike }
+import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfter, Matchers, FlatSpecLike }
 
 import com.netaporter.precanned.dsl.fancy._
 import spray.http.{ StatusCodes }
 
 /**
+ * Tests for the SlackNotifierExecutorTest
  * Created by johda411 on 2015-03-18.
  */
 class SlackNotifierExecutorTest extends TestKit(ActorSystem("SlackNotifierExecutorActorTestSystem"))
     with ImplicitSender
     with FlatSpecLike
     with BeforeAndAfter
+    with BeforeAndAfterAll
     with Matchers {
 
   val mockBindingPort = 8766
@@ -25,6 +27,7 @@ class SlackNotifierExecutorTest extends TestKit(ActorSystem("SlackNotifierExecut
 
   // Make sure expectations as cleared between tests.
   after { mockSlack.clearExpectations }
+  override def afterAll() { system.shutdown() }
 
   val conf =
     new SlackNotificationConfig(


### PR DESCRIPTION
Adding the NGI pipeline trigger. This also lead me to add some extra functionality in the rest of the code. 

One of these things was making it possible to add the original message that triggered a message on the progress channel. This means that we can check what that we actually only want messages indicating that demultiplexing has finished in the NGI pipeline trigger.

This also lead me to introducing a pre-filtering step in the NotifierActor trait making it possible to introduce any sort of pre-filtering in the Actor before passing messages on to the Executor, which I think is something that could be cool to have in other contexts in the future.