### PR TITLE
Feature/prep for hiseq x

### DIFF
--- a/src/main/scala/hercules/HerculesEntryPoint.scala
+++ b/src/main/scala/hercules/HerculesEntryPoint.scala
@@ -1,16 +1,14 @@
 package hercules
 
+import com.typesafe.config.ConfigFactory
+import hercules.HerculesStartRoles._
 import hercules.actors.demultiplexing.IlluminaDemultiplexingActor
 import hercules.actors.masters.SisyphusMasterActor
 import hercules.actors.processingunitwatcher.IlluminaProcessingUnitWatcherActor
 import hercules.api.RestAPI
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
-import akka.dispatch.Foreach
-import scala.collection.JavaConversions._
-import akka.event.Logging
 import org.slf4j.LoggerFactory
-import hercules.HerculesStartRoles._
+
+import scala.collection.JavaConversions._
 
 /**
  * Providing everything that Hercules needs to start up. Not keeping it in the

--- a/src/main/scala/hercules/actors/HerculesActor.scala
+++ b/src/main/scala/hercules/actors/HerculesActor.scala
@@ -1,6 +1,6 @@
 package hercules.actors
 
-import akka.actor.{Actor, ActorLogging}
+import akka.actor.{ Actor, ActorLogging }
 import hercules.actors.notifiers.NotifierManager
 import hercules.utils.VersionUtils
 

--- a/src/main/scala/hercules/actors/HerculesActor.scala
+++ b/src/main/scala/hercules/actors/HerculesActor.scala
@@ -1,7 +1,6 @@
 package hercules.actors
 
-import akka.actor.Actor
-import akka.actor.ActorLogging
+import akka.actor.{Actor, ActorLogging}
 import hercules.actors.notifiers.NotifierManager
 import hercules.utils.VersionUtils
 

--- a/src/main/scala/hercules/actors/masters/HerculesMasterActor.scala
+++ b/src/main/scala/hercules/actors/masters/HerculesMasterActor.scala
@@ -2,6 +2,7 @@ package hercules.actors.masters
 
 import akka.actor.ActorContext
 import hercules.actors.HerculesActor
+import hercules.actors.masters.state.MasterState
 
 /**
  * Hercules master actors should define a workflow to be run, e.g.

--- a/src/main/scala/hercules/actors/masters/HerculesMasterActor.scala
+++ b/src/main/scala/hercules/actors/masters/HerculesMasterActor.scala
@@ -1,6 +1,5 @@
 package hercules.actors.masters
 
-import akka.actor.ActorContext
 import hercules.actors.HerculesActor
 import hercules.actors.masters.state.MasterState
 

--- a/src/main/scala/hercules/actors/masters/SisyphusMasterActor.scala
+++ b/src/main/scala/hercules/actors/masters/SisyphusMasterActor.scala
@@ -1,5 +1,7 @@
 package hercules.actors.masters
 
+import hercules.actors.masters.state.MasterState
+
 import scala.concurrent.duration.DurationInt
 import com.typesafe.config.ConfigFactory
 import akka.actor.ActorRef

--- a/src/main/scala/hercules/actors/masters/state/MasterState.scala
+++ b/src/main/scala/hercules/actors/masters/state/MasterState.scala
@@ -1,9 +1,12 @@
-package hercules.actors.masters
+package hercules.actors.masters.state
 
-import hercules.protocols.HerculesMainProtocol._
-import hercules.entities.ProcessingUnit
 import hercules.actors.masters.MasterStateProtocol._
+import hercules.protocols.HerculesMainProtocol.{ ProcessingMessage, ProcessingUnitMessage, ProcessingUnitNameMessage }
+import spray.json.{ JsValue, JsObject, JsArray, DefaultJsonProtocol }
 
+/**
+ * Created by johda411 on 2015-04-21.
+ */
 case class MasterState(
     val messagesNotYetProcessed: Set[ProcessingMessage] = Set(),
     val messagesInProcessing: Set[ProcessingMessage] = Set(),
@@ -72,8 +75,14 @@ case class MasterState(
     )
   }
 
-  //@TODO It whould be awesome to attach a to Json method here to make it
-  // easy to drop this to json from the REST API later. /JD 20140929
-  def toJson = ???
+  def toJson: JsValue = {
+    def mapToJson(set: Set[ProcessingMessage]): JsArray =
+      JsArray(set.map(_.toJson).toVector)
+
+    JsObject(
+      "messagesNotYetProcessed" -> mapToJson(messagesNotYetProcessed),
+      "messagesInProcessing" -> mapToJson(messagesInProcessing),
+      "failedMessages" -> mapToJson(failedMessages))
+  }
 
 }

--- a/src/main/scala/hercules/actors/masters/state/MasterStateJsonProtocol.scala
+++ b/src/main/scala/hercules/actors/masters/state/MasterStateJsonProtocol.scala
@@ -1,0 +1,15 @@
+package hercules.actors.masters.state
+
+import spray.json.{ JsValue, RootJsonFormat, DefaultJsonProtocol }
+
+/**
+ * Created by johda411 on 2015-04-21.
+ */
+object MasterStateJsonProtocol extends DefaultJsonProtocol {
+
+  implicit object MessageJsonFormat extends RootJsonFormat[MasterState] {
+    override def read(json: JsValue): MasterState = ???
+    override def write(obj: MasterState): JsValue = obj.toJson
+  }
+
+}

--- a/src/main/scala/hercules/actors/notifiers/NotifierManager.scala
+++ b/src/main/scala/hercules/actors/notifiers/NotifierManager.scala
@@ -58,7 +58,7 @@ object NotifierManager {
 class NotifierManager(system: ActorSystem) {
 
   // TODO Make this configurable and start via reflections /JD 20150318
-  val actors = Seq(EmailNotifierActor(system), SlackNotifierActor(system))
+  val actors = Seq(EmailNotifierActor(system))
 
   /**
    * Send messages on the info channel

--- a/src/main/scala/hercules/api/Api.scala
+++ b/src/main/scala/hercules/api/Api.scala
@@ -1,7 +1,7 @@
 package hercules.api
 
-import spray.routing.RouteConcatenation
 import hercules.actors.api.RoutedHttpService
+import spray.routing.RouteConcatenation
 
 /**
  * The REST API layer. It exposes the REST services, but does not provide any

--- a/src/main/scala/hercules/api/Core.scala
+++ b/src/main/scala/hercules/api/Core.scala
@@ -2,6 +2,7 @@ package hercules.api
 
 import akka.actor.ActorSystem
 import akka.util.Timeout
+import com.typesafe.config.ConfigFactory
 
 import scala.concurrent.duration.Duration
 
@@ -25,7 +26,7 @@ trait BootedCore extends Core {
   /**
    * Construct the ActorSystem we will use in our application
    */
-  implicit lazy val system = ActorSystem("hercules-rest-api")
+  implicit lazy val system = ActorSystem("hercules-rest-api", ConfigFactory.load())
   /**
    * Define the timeout value used throughout the API
    */

--- a/src/main/scala/hercules/api/Web.scala
+++ b/src/main/scala/hercules/api/Web.scala
@@ -1,10 +1,8 @@
 package hercules.api
 
 import akka.io.IO
-import spray.can.Http
 import akka.pattern.ask
-import akka.util.Timeout
-import scala.concurrent.duration.Duration
+import spray.can.Http
 
 /**
  * Provides the web server (spray-can) for the REST api in ``Api``, using the actor system

--- a/src/main/scala/hercules/api/services/DemultiplexingService.scala
+++ b/src/main/scala/hercules/api/services/DemultiplexingService.scala
@@ -6,9 +6,10 @@ import akka.pattern.ask
 import akka.util.Timeout
 
 import com.wordnik.swagger.annotations._
+import hercules.actors.masters.state.MasterState
 
 import hercules.protocols.HerculesMainProtocol._
-import hercules.actors.masters.{ MasterState, MasterStateProtocol }
+import hercules.actors.masters.MasterStateProtocol
 
 import javax.ws.rs.Path
 

--- a/src/main/scala/hercules/api/services/StatusService.scala
+++ b/src/main/scala/hercules/api/services/StatusService.scala
@@ -63,7 +63,6 @@ trait StatusService extends HerculesService {
          */
         detach() {
 
-          val timeout = Timeout(3.seconds)
           /**
            * Request the state of the active master
            */
@@ -72,7 +71,7 @@ trait StatusService extends HerculesService {
               SendToAll(
                 "/user/master/active",
                 RequestMasterState())
-            )(timeout)
+            )
 
           /**
            * Take the response from master and map it to a StatusCode

--- a/src/main/scala/hercules/api/services/StatusService.scala
+++ b/src/main/scala/hercules/api/services/StatusService.scala
@@ -6,15 +6,15 @@ import akka.pattern.ask
 import akka.util.Timeout
 
 import com.wordnik.swagger.annotations._
+import hercules.actors.masters.state.MasterState
 
 import scala.concurrent.ExecutionContext
 
 import spray.http.StatusCodes._
-import spray.routing._
-
-import hercules.actors.masters.MasterState
 import hercules.protocols.HerculesMainProtocol.RequestMasterState
 import hercules.api.models
+
+import spray.httpx.SprayJsonSupport._
 
 /**
  * The StatusService trait define operations for querying the status of the tasks in Master.
@@ -52,13 +52,13 @@ trait StatusService extends HerculesService {
   /**
    * The /status endpoint for GET
    */
-  private def getRoute = get {
-    path("status") {
-      /**
-       * Complete the request asynchronously
-       */
-      detach() {
-        complete {
+  private def getRoute =
+    get {
+      path("status") {
+        /**
+         * Complete the request asynchronously
+         */
+        detach() {
           /**
            * Request the state of the active master
            */
@@ -68,31 +68,18 @@ trait StatusService extends HerculesService {
                 "/user/master/active",
                 RequestMasterState())
             )
+
           /**
            * Take the response from master and map it to a StatusCode
            */
-          val response = request.map {
-            case MasterState(messagesNotYetProcessed, messagesInProcessing, failedMessages) => {
-              // @TODO Let some json marshaller handle the response instead
-              val status =
-                "messagesNotYetProcessed: {" +
-                  messagesNotYetProcessed.mkString(",") +
-                  "}, messagesInProcessing: {" +
-                  messagesInProcessing.mkString(",") +
-                  "} ,failedMessages: {" +
-                  failedMessages.mkString("}")
-              OK
-            }
-            /**
-             * Handle exceptions that may be thrown
-             */
-          }.recover {
-            case e: Exception =>
-              InternalServerError
+
+          import hercules.actors.masters.state.MasterStateJsonProtocol._
+
+          onSuccess(request) {
+            case state: MasterState => complete(state)
+            case e: Exception       => complete(InternalServerError)
           }
-          response
         }
       }
     }
-  }
 }

--- a/src/main/scala/hercules/config/processingunit/IlluminaProcessingUnitConfig.scala
+++ b/src/main/scala/hercules/config/processingunit/IlluminaProcessingUnitConfig.scala
@@ -2,6 +2,8 @@ package hercules.config.processingunit
 
 import java.io.File
 
+import spray.json.{ JsString, JsObject, JsValue }
+
 /**
  * Provides the configuration files for a IlluminaProcessingUnit
  *
@@ -14,4 +16,15 @@ case class IlluminaProcessingUnitConfig(
     QCConfig: File,
     programConfig: Option[File]) extends ProcessingUnitConfig {
 
+  override def toJson: JsValue = {
+
+    val programConfigFileString =
+      if (programConfig.isDefined) programConfig.get.getAbsolutePath
+      else "no program config set"
+
+    JsObject("samplesheet" -> JsString(sampleSheet.getAbsolutePath),
+      "qcconfig" -> JsString(QCConfig.getAbsolutePath),
+      "programconfig" -> JsString(programConfigFileString))
+
+  }
 }

--- a/src/main/scala/hercules/config/processingunit/ProcessingUnitConfig.scala
+++ b/src/main/scala/hercules/config/processingunit/ProcessingUnitConfig.scala
@@ -1,8 +1,12 @@
 package hercules.config.processingunit
 
+import spray.json.JsValue
+
 /**
  * Base class for configuring a processing unit
  */
 abstract class ProcessingUnitConfig() {
+
+  def toJson: JsValue = ???
 
 }

--- a/src/main/scala/hercules/entities/ProcessingUnit.scala
+++ b/src/main/scala/hercules/entities/ProcessingUnit.scala
@@ -2,6 +2,8 @@ package hercules.entities
 
 import java.net.URI
 
+import spray.json.{ JsBoolean, JsString, JsObject, JsValue }
+
 /**
  * A atomic unit to be processed by Hercules. E.g. a Illumina runfolder.
  */
@@ -21,5 +23,25 @@ trait ProcessingUnit {
    * Specify if this processing unit has already been found.
    */
   def isFound: Boolean
+
+  /**
+   * Values to be mapped to json representation.
+   * Override in implementing class to add more information.
+   * @return the key value pairs representing the object in json
+   */
+  protected def mappedValues: Map[String, JsValue] =
+    Map(
+      "name" -> JsString(name),
+      "uri" -> JsString(uri.toString),
+      "isFound" -> JsBoolean(isFound)
+    )
+
+  /**
+   * Convert processing unit to json
+   * @return the json representation of the ProcessingUnit
+   */
+  def toJson: JsValue = {
+    JsObject(mappedValues)
+  }
 
 }

--- a/src/main/scala/hercules/entities/ProcessingUnit.scala
+++ b/src/main/scala/hercules/entities/ProcessingUnit.scala
@@ -2,7 +2,7 @@ package hercules.entities
 
 import java.net.URI
 
-import spray.json.{JsBoolean, JsObject, JsString, JsValue}
+import spray.json.{ JsBoolean, JsObject, JsString, JsValue }
 
 /**
  * A atomic unit to be processed by Hercules. E.g. a Illumina runfolder.

--- a/src/main/scala/hercules/entities/ProcessingUnit.scala
+++ b/src/main/scala/hercules/entities/ProcessingUnit.scala
@@ -2,7 +2,7 @@ package hercules.entities
 
 import java.net.URI
 
-import spray.json.{ JsBoolean, JsString, JsObject, JsValue }
+import spray.json.{JsBoolean, JsObject, JsString, JsValue}
 
 /**
  * A atomic unit to be processed by Hercules. E.g. a Illumina runfolder.

--- a/src/main/scala/hercules/entities/ProcessingUnitFetcher.scala
+++ b/src/main/scala/hercules/entities/ProcessingUnitFetcher.scala
@@ -1,6 +1,5 @@
 package hercules.entities
 
-import hercules.config.processingunit.ProcessingUnitConfig
 import hercules.config.processingunit.ProcessingUnitFetcherConfig
 
 /**

--- a/src/main/scala/hercules/entities/illumina/HiSeqProcessingUnit.scala
+++ b/src/main/scala/hercules/entities/illumina/HiSeqProcessingUnit.scala
@@ -5,7 +5,7 @@ import java.net.URI
 import hercules.config.processingunit.IlluminaProcessingUnitConfig
 
 /**
- * Represent a HiSeq runfolder
+ * Represent a HiSeq or HiSeq X runfolder
  * @param processingUnitConfig
  * @param uri pointing to the runfolder
  */

--- a/src/main/scala/hercules/entities/illumina/IlluminaProcessingUnit.scala
+++ b/src/main/scala/hercules/entities/illumina/IlluminaProcessingUnit.scala
@@ -7,6 +7,10 @@ import hercules.config.processingunit.IlluminaProcessingUnitConfig
 import hercules.entities.ProcessingUnit
 import hercules.utils.VersionUtils
 
+object IlluminaProcessingUnit {
+  val nameOfIndicatorFile = "found"
+}
+
 /**
  * Provides a base for representing a Illumina runfolder.
  */
@@ -24,7 +28,7 @@ trait IlluminaProcessingUnit extends ProcessingUnit {
    * The indicator file dropped when the processing unit is marked as found.
    */
   private def indicatorFile: File =
-    new File(uri.getPath + File.separator + "found")
+    new File(uri.getPath + File.separator + IlluminaProcessingUnit.nameOfIndicatorFile)
 
   /**
    * Is found is true if the indicator file exists.

--- a/src/main/scala/hercules/entities/illumina/IlluminaProcessingUnit.scala
+++ b/src/main/scala/hercules/entities/illumina/IlluminaProcessingUnit.scala
@@ -6,6 +6,7 @@ import java.net.URI
 import hercules.config.processingunit.IlluminaProcessingUnitConfig
 import hercules.entities.ProcessingUnit
 import hercules.utils.VersionUtils
+import spray.json.JsValue
 
 object IlluminaProcessingUnit {
   val nameOfIndicatorFile = "found"
@@ -18,6 +19,15 @@ trait IlluminaProcessingUnit extends ProcessingUnit {
 
   val processingUnitConfig: IlluminaProcessingUnitConfig
   val uri: URI
+
+  /**
+   * Values to be mapped to json representation.
+   * Override in implementing class to add more information.
+   * @return the key value pairs representing the object in json
+   */
+  override protected def mappedValues: Map[String, JsValue] = {
+    super.mappedValues.updated("config", processingUnitConfig.toJson)
+  }
 
   /**
    * Get the name from the runfolder directory name

--- a/src/main/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcher.scala
+++ b/src/main/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcher.scala
@@ -293,11 +293,11 @@ class IlluminaProcessingUnitFetcher() extends ProcessingUnitFetcher {
       val unitConfig =
         new IlluminaProcessingUnitConfig(samplesheet, qcConfig, Some(programConfig))
 
-      //@TODO Some nicer solution for picking up if it's a HiSeq or MiSeq
       getMachineTypeFromRunParametersXML(runfolder) match {
         case "MiSeq Control Software" => Some(new MiSeqProcessingUnit(unitConfig, runfolder.toURI(),
           getManifestFilesFromRunParametersXML(runfolder).size > 0))
         case "HiSeq Control Software" => Some(new HiSeqProcessingUnit(unitConfig, runfolder.toURI()))
+        case "HiSeq X Control Software" => Some(new HiSeqProcessingUnit(unitConfig, runfolder.toURI()))
         case s: String                => throw new Exception(s"Unrecognized type string:  $s")
       }
 

--- a/src/main/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcher.scala
+++ b/src/main/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcher.scala
@@ -36,6 +36,25 @@ class IlluminaProcessingUnitFetcher() extends ProcessingUnitFetcher {
   type ProcessingUnitType = IlluminaProcessingUnit
 
   /**
+   * Checks is a runfolder is ready for processing based on the
+   * path to the runfolder.
+   * @param runfolder path to the runfolder
+   * @return true if the runfolder should be processed.
+   */
+  def isReadyForProcessing(runfolder: File): Boolean = {
+
+    val filesInRunFolder = runfolder.listFiles()
+
+    val hasIndicatorFile =
+      filesInRunFolder.exists(x => x.getName() == IlluminaProcessingUnit.nameOfIndicatorFile)
+
+    val hasRTAComplete =
+      filesInRunFolder.exists(x => x.getName() == "RTAComplete.txt")
+
+    !hasIndicatorFile && hasRTAComplete
+  }
+
+  /**
    * Indicate if the unit is ready to be processed.
    * Normally this involves checking files on the file system or reading it's
    * status from a database.
@@ -44,17 +63,8 @@ class IlluminaProcessingUnitFetcher() extends ProcessingUnitFetcher {
    * @return if the processing unit is ready to be processed or not.
    */
   def isReadyForProcessing(unit: IlluminaProcessingUnit): Boolean = {
-
     val runfolderPath = new File(unit.uri)
-
-    val filesInRunFolder = runfolderPath.listFiles()
-
-    val hasNoFoundFile = !unit.isFound
-
-    val hasRTAComplete =
-      filesInRunFolder.exists(x => x.getName() == "RTAComplete.txt")
-
-    hasNoFoundFile && hasRTAComplete
+    isReadyForProcessing(runfolderPath)
   }
 
   /**
@@ -88,7 +98,6 @@ class IlluminaProcessingUnitFetcher() extends ProcessingUnitFetcher {
 
     for {
       unit <- getProcessingUnits(config)
-      if isReadyForProcessing(unit)
     } yield {
       unit.markAsFound
       unit
@@ -296,15 +305,16 @@ class IlluminaProcessingUnitFetcher() extends ProcessingUnitFetcher {
       getMachineTypeFromRunParametersXML(runfolder) match {
         case "MiSeq Control Software" => Some(new MiSeqProcessingUnit(unitConfig, runfolder.toURI(),
           getManifestFilesFromRunParametersXML(runfolder).size > 0))
-        case "HiSeq Control Software" => Some(new HiSeqProcessingUnit(unitConfig, runfolder.toURI()))
+        case "HiSeq Control Software"   => Some(new HiSeqProcessingUnit(unitConfig, runfolder.toURI()))
         case "HiSeq X Control Software" => Some(new HiSeqProcessingUnit(unitConfig, runfolder.toURI()))
-        case s: String                => throw new Exception(s"Unrecognized type string:  $s")
+        case s: String                  => throw new Exception(s"Unrecognized type string:  $s")
       }
 
     }
 
     for {
       runfolder <- searchForRunfolders()
+      if isReadyForProcessing(runfolder)
       samplesheet <- searchForSamplesheet(runfolder)
       qcConfig <- getQCConfig(runfolder)
       programConfig <- getProgramConfig(runfolder)

--- a/src/main/scala/hercules/protocols/HerculesMainProtocol.scala
+++ b/src/main/scala/hercules/protocols/HerculesMainProtocol.scala
@@ -1,7 +1,7 @@
 package hercules.protocols
 
-import hercules.entities.notification.NotificationUnit
 import hercules.entities.ProcessingUnit
+import hercules.entities.notification.NotificationUnit
 import spray.json._
 
 /**

--- a/src/main/scala/hercules/protocols/HerculesMainProtocol.scala
+++ b/src/main/scala/hercules/protocols/HerculesMainProtocol.scala
@@ -1,8 +1,8 @@
 package hercules.protocols
 
-import hercules.entities.ProcessingUnit
 import hercules.entities.notification.NotificationUnit
 import hercules.entities.ProcessingUnit
+import spray.json._
 
 /**
  * Import this object to gain access to the messaging protocol of
@@ -20,19 +20,40 @@ object HerculesMainProtocol {
    * This trait is the base for all messages in the Hercules application
    * All messages to be parsed need to extend this!
    */
-  sealed trait HerculesMessage
+  sealed trait HerculesMessage {
+    protected val name: String = getClass.getSimpleName
+
+    /**
+     * The values of the object to be mapped to json
+     * Override to add more information about an object
+     * The minimum information added is the type of the message.
+     * @return
+     */
+    protected def mappedValues: Map[String, JsValue] = Map("type" -> (JsString(name)))
+
+    /**
+     * Provides the json representation of a message.
+     * Will as a minimum contain the type of the message.
+     * @return
+     */
+    def toJson: JsValue = JsObject(mappedValues)
+  }
 
   /**
    * Use this to acknowledge e.g. that some work was accepted
    */
-  case class Acknowledge extends HerculesMessage
+  case class Acknowledge() extends HerculesMessage {}
 
   /**
    * Use this to Reject a something, like a work load. Optionally include a
    * reason.
    * @param reason what something was rejected.
    */
-  case class Reject(reason: Option[String] = None) extends HerculesMessage
+  case class Reject(reason: Option[String] = None) extends HerculesMessage {
+    override def mappedValues =
+      super.mappedValues.updated(
+        "reason", JsString(reason.getOrElse("Unknown reason")))
+  }
 
   /**
    * TODO: This should probably realy be moved out into a MasterProtocol,
@@ -42,7 +63,11 @@ object HerculesMainProtocol {
    * the full state should be returned. This can be used for example the details
    * @param unitName the name of the processing unit to look for
    */
-  case class RequestMasterState(unitName: Option[String] = None) extends HerculesMessage
+  case class RequestMasterState(unitName: Option[String] = None) extends HerculesMessage {
+    override def mappedValues =
+      super.mappedValues.updated(
+        "unitName", JsString(unitName.getOrElse("Unknown unit")))
+  }
 
   //--------------------------------------------------------------
   // MESSAGES ABOUT FINDING AND FORGETTING PROCESSING UNITS
@@ -60,6 +85,10 @@ object HerculesMainProtocol {
    */
   trait ProcessingUnitMessage extends ProcessingMessage {
     val unit: ProcessingUnit
+
+    override def mappedValues =
+      super.mappedValues.updated(
+        "unit", unit.toJson)
   }
   /**
    * Used for when the you don't have a ProcessingUnit, but just a name,
@@ -67,6 +96,10 @@ object HerculesMainProtocol {
    */
   trait ProcessingUnitNameMessage extends ProcessingMessage {
     val unitName: String
+
+    override def mappedValues =
+      super.mappedValues.updated(
+        "unitname", JsString(unitName))
   }
 
   /**
@@ -128,7 +161,11 @@ object HerculesMainProtocol {
    * @param unit processing unit
    * @param reason why it failed.
    */
-  case class FailedDemultiplexingProcessingUnitMessage(unit: ProcessingUnit, reason: String) extends DemultiplexingMessage with ProcessingUnitMessage
+  case class FailedDemultiplexingProcessingUnitMessage(unit: ProcessingUnit, reason: String) extends DemultiplexingMessage with ProcessingUnitMessage {
+    override def mappedValues =
+      super.mappedValues.updated(
+        "reason", JsString(reason))
+  }
 
   /**
    * Send to indicate the demultiplexing of a processing unit should be restarted.

--- a/src/main/scala/hercules/protocols/HerculesMainProtocolJsonProtocol.scala
+++ b/src/main/scala/hercules/protocols/HerculesMainProtocolJsonProtocol.scala
@@ -1,0 +1,24 @@
+package hercules.protocols
+
+import hercules.protocols.HerculesMainProtocol.HerculesMessage
+import spray.json.{ JsValue, RootJsonFormat, DefaultJsonProtocol }
+
+/**
+ * Handles conversion from the messages in the HerculesMainProtocol to Json
+ * This is used by the API to provide information about state to the
+ * outside world.
+ *
+ * TODO Right now converting from json to class instances is not supported.
+ * At the moment we don't need that, but it can be implemented here in the future.
+ * /JD 2015-04-21
+ *
+ * Created by johda411 on 2015-04-21.
+ */
+object HerculesMainProtocolJsonProtocol extends DefaultJsonProtocol {
+
+  implicit object MessageJsonFormat extends RootJsonFormat[HerculesMessage] {
+    override def read(json: JsValue): HerculesMessage = ???
+    override def write(obj: HerculesMessage): JsValue = obj.toJson
+  }
+
+}

--- a/src/main/scala/hercules/utils/Conversions.scala
+++ b/src/main/scala/hercules/utils/Conversions.scala
@@ -1,8 +1,7 @@
 package hercules.utils
 
 import java.io.File
-import java.net.URI
-import java.net.InetAddress
+import java.net.{InetAddress, URI}
 
 /**
  * Provide useful conversion

--- a/src/main/scala/hercules/utils/Conversions.scala
+++ b/src/main/scala/hercules/utils/Conversions.scala
@@ -1,7 +1,7 @@
 package hercules.utils
 
 import java.io.File
-import java.net.{InetAddress, URI}
+import java.net.{ InetAddress, URI }
 
 /**
  * Provide useful conversion

--- a/src/test/scala/hercules/actors/master/SisyphusMasterActorTest.scala
+++ b/src/test/scala/hercules/actors/master/SisyphusMasterActorTest.scala
@@ -7,6 +7,7 @@ import akka.actor.ActorLogging
 import akka.testkit.{ ImplicitSender, TestActorRef, TestKit, TestProbe }
 import akka.actor.ActorSystem
 import com.typesafe.config.ConfigFactory
+import hercules.actors.masters.state.MasterState
 import hercules.config.masters.MasterActorConfig
 import hercules.actors.masters.SisyphusMasterActor
 import hercules.entities.illumina.IlluminaProcessingUnit
@@ -34,7 +35,6 @@ import akka.contrib.pattern.ClusterClient
 import akka.actor.RootActorPath
 import akka.persistence.SnapshotSelectionCriteria
 import org.scalatest.BeforeAndAfterEach
-import hercules.actors.masters.MasterState
 
 class SisyphusMasterActorTest() extends TestKit(ActorSystem("SisyphusMasterActorTestSystem"))
     with FlatSpecLike

--- a/src/test/scala/hercules/api/services/MockBackend.scala
+++ b/src/test/scala/hercules/api/services/MockBackend.scala
@@ -76,8 +76,7 @@ class MockBackend(
                   if (state.findStateOfUnit(Some(id)).messagesInProcessing.isEmpty) Acknowledge
                   else Reject(Some(s"Processing Unit $id is being processed"))
               }
-
-            println(s"doNotAnswer: $doNotAnswer")
+            
             if (!doNotAnswer) {
               sender ! response
             }

--- a/src/test/scala/hercules/api/services/MockBackend.scala
+++ b/src/test/scala/hercules/api/services/MockBackend.scala
@@ -5,7 +5,8 @@ import akka.contrib.pattern.ClusterClient.SendToAll
 import akka.testkit.{ TestActor, TestProbe }
 import akka.util.Timeout
 
-import hercules.actors.masters.{ MasterState, MasterStateProtocol }
+import hercules.actors.masters.MasterStateProtocol
+import hercules.actors.masters.state.MasterState
 import hercules.entities.ProcessingUnit
 import hercules.protocols.HerculesMainProtocol._
 

--- a/src/test/scala/hercules/api/services/StatusServiceTest.scala
+++ b/src/test/scala/hercules/api/services/StatusServiceTest.scala
@@ -58,7 +58,7 @@ class StatusServiceTest
 
     // Ensure that this timeout is longer than the one used by
     // the actual service.
-    implicit val routeTestTimeout = RouteTestTimeout(5.second)
+    implicit val routeTestTimeout = RouteTestTimeout(7.second)
 
     val exceptionProbe = MockBackend(
       system = this.system,

--- a/src/test/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcherTest.scala
+++ b/src/test/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcherTest.scala
@@ -324,7 +324,7 @@ class IlluminaProcessingUnitFetcherTest extends FlatSpec with Matchers with Befo
             new File("test_samplesheets/140806_D00457_0045_AC47TFACXX_samplesheet.csv"),
             new File("default_qc_config"),
             Some(new File("default_program_config"))),
-          new File("/home/MOLMED/johda411/workspace/hercules/test_runfolders/140806_D00457_0045_AC47TFACXX/").toURI))
+          new File("test_runfolders/140806_D00457_0045_AC47TFACXX/").toURI))
 
     assert(result === expected)
 

--- a/src/test/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcherTest.scala
+++ b/src/test/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcherTest.scala
@@ -173,7 +173,7 @@ class IlluminaProcessingUnitFetcherTest extends FlatSpec with Matchers with Befo
     val firstCreateTwoRunfolders: Seq[IlluminaProcessingUnit] = generateExpectedRunfolders(runfolders, 2)
 
     val pathToFoundFolder = new File(firstCreateTwoRunfolders(1).uri)
-    val foundFile = new File(pathToFoundFolder + "/found")
+    val foundFile = new File(pathToFoundFolder + "/" + IlluminaProcessingUnit.nameOfIndicatorFile)
     foundFile.createNewFile()
 
     val expected = firstCreateTwoRunfolders(0)
@@ -191,7 +191,7 @@ class IlluminaProcessingUnitFetcherTest extends FlatSpec with Matchers with Befo
 
     // Add a found file to the second runfolder
     // which means that only the first runfolder should be found
-    new File(runfolders(1) + "/found").createNewFile()
+    new File(runfolders(1) + "/" + IlluminaProcessingUnit.nameOfIndicatorFile).createNewFile()
 
     val fetcher = new IlluminaProcessingUnitFetcher()
     val actual = fetcher.checkForReadyProcessingUnits(fetcherConfig)
@@ -295,6 +295,39 @@ class IlluminaProcessingUnitFetcherTest extends FlatSpec with Matchers with Befo
       val fetcher = new IlluminaProcessingUnitFetcher()
       val actual = fetcher.checkForReadyProcessingUnits(fetcherConfig)
     }
+  }
+
+  it should "be able to check if a runfolder is ready or not" in {
+    val createdRunfolder: Seq[IlluminaProcessingUnit] = generateExpectedRunfolders(runfolders, 2)
+    val fetcher = new IlluminaProcessingUnitFetcher()
+
+    // The first one is ready
+    assert(fetcher.isReadyForProcessing(createdRunfolder(0)))
+
+    // Mark second one as found, and therefore is not ready
+    new File(runfolders(1) + "/" + IlluminaProcessingUnit.nameOfIndicatorFile).createNewFile()
+    assert(!fetcher.isReadyForProcessing(createdRunfolder(1)))
+
+  }
+
+  it should "be able to search for runfolders by name" in {
+
+    val createdRunfolder: Seq[IlluminaProcessingUnit] = generateExpectedRunfolders(runfolders, 1)
+    val fetcher = new IlluminaProcessingUnitFetcher()
+
+    val result = fetcher.searchForProcessingUnitName("140806_D00457_0045_AC47TFACXX", fetcherConfig)
+
+    val expected =
+      Some(
+        HiSeqProcessingUnit(
+          IlluminaProcessingUnitConfig(
+            new File("test_samplesheets/140806_D00457_0045_AC47TFACXX_samplesheet.csv"),
+            new File("default_qc_config"),
+            Some(new File("default_program_config"))),
+          new File("/home/MOLMED/johda411/workspace/hercules/test_runfolders/140806_D00457_0045_AC47TFACXX/").toURI))
+
+    assert(result === expected)
+
   }
 
 }

--- a/src/test/scala/hercules/entities/illumina/IlluminaProcessingUnitTest.scala
+++ b/src/test/scala/hercules/entities/illumina/IlluminaProcessingUnitTest.scala
@@ -5,11 +5,16 @@ import java.net.URI
 
 import hercules.config.processingunit.IlluminaProcessingUnitConfig
 import org.scalatest.{ FlatSpec }
+import spray.json.{ JsObject, JsBoolean, JsString, JsValue }
 
 /**
  * Created by johda411 on 2015-04-21.
  */
 class IlluminaProcessingUnitTest extends FlatSpec {
+
+  val name = "test"
+  val uriToUse = new File(name).toURI
+  val found = true
 
   val progConfig = Some(new File("qc"))
   val qcConfig = new File("qc")
@@ -18,16 +23,24 @@ class IlluminaProcessingUnitTest extends FlatSpec {
   val config = new IlluminaProcessingUnitConfig(sampleSheet, qcConfig, progConfig)
 
   val processingUnit = new IlluminaProcessingUnit {
-    override val uri: URI = new File("test").toURI
+    override val uri: URI = uriToUse
     override val processingUnitConfig: IlluminaProcessingUnitConfig = config
+    override def isFound: Boolean = found
   }
 
   "A Illumina processing unit" should "have a json representation" in {
 
     val expectedJson =
-      """{"name":"test","uri":"file:/home/MOLMED/johda411/workspace/hercules/test","isFound":false,"config":{"samplesheet":"/home/MOLMED/johda411/workspace/hercules/sampleSheet","qcconfig":"/home/MOLMED/johda411/workspace/hercules/qc","programconfig":"/home/MOLMED/johda411/workspace/hercules/qc"}}"""
+      JsObject(Map(
+        "name" -> JsString(name),
+        "uri" -> JsString(uriToUse.toString),
+        "isFound" -> JsBoolean(found),
+        "config" -> config.toJson)
+      )
 
-    assert(processingUnit.toJson.toString() === expectedJson.toString)
+    val asJson = processingUnit.toJson
+
+    assert(asJson.asJsObject === expectedJson)
 
   }
 

--- a/src/test/scala/hercules/entities/illumina/IlluminaProcessingUnitTest.scala
+++ b/src/test/scala/hercules/entities/illumina/IlluminaProcessingUnitTest.scala
@@ -1,0 +1,34 @@
+package hercules.entities.illumina
+
+import java.io.File
+import java.net.URI
+
+import hercules.config.processingunit.IlluminaProcessingUnitConfig
+import org.scalatest.{ FlatSpec }
+
+/**
+ * Created by johda411 on 2015-04-21.
+ */
+class IlluminaProcessingUnitTest extends FlatSpec {
+
+  val progConfig = Some(new File("qc"))
+  val qcConfig = new File("qc")
+  val sampleSheet = new File("sampleSheet")
+
+  val config = new IlluminaProcessingUnitConfig(sampleSheet, qcConfig, progConfig)
+
+  val processingUnit = new IlluminaProcessingUnit {
+    override val uri: URI = new File("test").toURI
+    override val processingUnitConfig: IlluminaProcessingUnitConfig = config
+  }
+
+  "A Illumina processing unit" should "have a json representation" in {
+
+    val expectedJson =
+      """{"name":"test","uri":"file:/home/MOLMED/johda411/workspace/hercules/test","isFound":false,"config":{"samplesheet":"/home/MOLMED/johda411/workspace/hercules/sampleSheet","qcconfig":"/home/MOLMED/johda411/workspace/hercules/qc","programconfig":"/home/MOLMED/johda411/workspace/hercules/qc"}}"""
+
+    assert(processingUnit.toJson.toString() === expectedJson.toString)
+
+  }
+
+}

--- a/src/test/scala/hercules/protocols/HerculesMainProtocolJsonProtocolTest.scala
+++ b/src/test/scala/hercules/protocols/HerculesMainProtocolJsonProtocolTest.scala
@@ -1,0 +1,18 @@
+package hercules.protocols
+
+import hercules.protocols.HerculesMainProtocol.HerculesMessage
+import org.scalatest.FlatSpec
+
+/**
+ * Created by johda411 on 2015-04-21.
+ */
+class HerculesMainProtocolJsonProtocolTest extends FlatSpec {
+
+  val messageFormat = HerculesMainProtocolJsonProtocol.MessageJsonFormat
+
+  "A HerculesMainProtocolJsonProtocolTest " should "convert messages to Json" in {
+    val message: HerculesMessage = new HerculesMainProtocol.Acknowledge()
+    assert(messageFormat.write(message).toString() === """{"type":"Acknowledge"}""")
+  }
+
+}


### PR DESCRIPTION
Some work related to making sure everything works for the HiSeq X.

Also:
 - Refactored how runfolders are picked up so we don't go searching for samplesheets etc. for runs which should be skipped (see c87a8da).
 - Removed the slack notifier for now. Since at the moment there is no way to dynamically load which notifiers are active, this seemed like a good choice.
 - Work on the status API, so that it can now answers with the master state in json. In addition to this I made sure that any `HerculesMessage` should be possible to serialize to json if we should wish to do so. Still pending however is deserializing from json, which is a bit trickerier, and since we don't need that feature at the moment I've simply left it unimplemented.