### PR TITLE
Removing non-ready stuff and fix runfolder pickup

### DIFF
--- a/src/main/scala/hercules/api/CoreActors.scala
+++ b/src/main/scala/hercules/api/CoreActors.scala
@@ -24,11 +24,12 @@ trait CoreActors extends MasterLookup {
       implicit val clusterClient = cluster
       implicit val to = timeout
     },
-    new DemultiplexingService {
-      def actorRefFactory = system
-      implicit val clusterClient = cluster
-      implicit val to = timeout
-    },
+    // TODO Temporarily disabled. /JD 20150507
+    //    new DemultiplexingService {
+    //      def actorRefFactory = system
+    //      implicit val clusterClient = cluster
+    //      implicit val to = timeout
+    //    },
     new SwaggerService with HerculesService {
       def actorRefFactory = system
     })

--- a/src/main/scala/hercules/api/services/DemultiplexingService.scala
+++ b/src/main/scala/hercules/api/services/DemultiplexingService.scala
@@ -1,273 +1,277 @@
-package hercules.api.services
 
-import akka.actor.{ Actor, ActorRef }
-import akka.contrib.pattern.ClusterClient.SendToAll
-import akka.pattern.ask
-import akka.util.Timeout
+// TODO Temporarily disabled on 7/5 2015 awaiting
+//      redesign. /JD 20150507
 
-import com.wordnik.swagger.annotations._
-import hercules.actors.masters.state.MasterState
-
-import hercules.protocols.HerculesMainProtocol._
-import hercules.actors.masters.MasterStateProtocol
-
-import javax.ws.rs.Path
-
-import scala.concurrent.ExecutionContext
-
-import spray.http.StatusCodes._
-import spray.routing._
-
-/**
- * The DemultiplexingService trait define operations for interacting with tasks related to demultiplexing.
- */
-@Api(
-  value = "/demultiplex",
-  description = "Control demultiplexing tasks.")
-trait DemultiplexingService extends HerculesService {
-
-  implicit def ec: ExecutionContext = actorRefFactory.dispatcher
-  implicit val clusterClient: ActorRef
-  implicit val to: Timeout
-  import MasterStateProtocol._
-
-  /**
-   * The concatenated route for this service
-   */
-  def route =
-    pathPrefix("demultiplex" / Segment) { id =>
-      restartFailedDemultiplexJob(id) ~
-        removeFailedDemultiplexJob(id) ~
-        forgetDemultiplexJob(id)
-    }
-
-  /**
-   * Tell the master to restart a demultiplex job that has previously
-   * failed and which the master has in its list of failed units
-   */
-  @Path("/{ID}/restart")
-  @ApiOperation(
-    value = "Restart a failed demultiplex task",
-    notes = "Send a message requesting that the Master will re-queue a previously failed demultiplex task.",
-    httpMethod = "PUT",
-    nickname = "Restart",
-    produces = "application/json")
-  @ApiImplicitParams(Array(
-    new ApiImplicitParam(name = "ID", value = "ID of the Processing Unit to process. Typically corresponds to the name of the runfolder.", required = true, dataType = "string", paramType = "path")
-  ))
-  @ApiResponses(
-    Array(
-      new ApiResponse(
-        code = 500,
-        message = "An exception occurred"),
-      new ApiResponse(
-        code = 202,
-        message = "Accepted")
-    ))
-  def restartFailedDemultiplexJob(id: String) =
-    path("restart") {
-      put {
-        /**
-         * Complete the request asynchronously
-         */
-        detach() {
-          complete {
-            /**
-             * Send a request to restart the Processing Unit corresponding to the supplied id. The response is mapped to an appropriate StatusCode.
-             */
-            clusterClient.ask(
-              SendToAll(
-                "/user/master/active",
-                RestartDemultiplexingProcessingUnitMessage(id))
-            ).map {
-                case Acknowledge =>
-                  Accepted
-                case Reject(reason) =>
-                  NotFound
-                /**
-                 * Handle exceptions that may be thrown.
-                 */
-              }.recover {
-                case e: Exception =>
-                  InternalServerError
-              }
-          }
-        }
-      }
-    }
-
-  /**
-   * Remove a failed demultiplex job from the master's list of failed demultiplex jobs.
-   * If successful, this job will not be retried.
-   */
-  @Path("/{ID}/remove")
-  @ApiOperation(
-    value = "Remove a failed demultiplex task",
-    notes = "Send a message requesting that the Master will remove a previously failed demultiplex task from its list of tasks.",
-    httpMethod = "DELETE",
-    nickname = "Remove",
-    produces = "application/json")
-  @ApiImplicitParams(Array(
-    new ApiImplicitParam(name = "ID", value = "ID of the Processing Unit to process. Typically corresponds to the name of the runfolder.", required = true, dataType = "string", paramType = "path")
-  ))
-  @ApiResponses(
-    Array(
-      new ApiResponse(
-        code = 500,
-        message = "An exception occurred"),
-      new ApiResponse(
-        code = 200,
-        message = "OK"),
-      new ApiResponse(
-        code = 404,
-        message = "Not found")
-    ))
-  def removeFailedDemultiplexJob(id: String) =
-    path("remove") {
-      delete {
-        /**
-         * Complete the request asynchronously
-         */
-        detach() {
-          complete {
-            /**
-             * Request the message containing the Processing Unit from master.
-             */
-            val request =
-              clusterClient.ask(
-                SendToAll(
-                  "/user/master/active",
-                  RequestMasterState(Some(id)))
-              )
-            /**
-             * If a matching message was found, request master to remove it from its state, otherwise return a 404 status code.
-             */
-            val response = request.map {
-              case ms: MasterState => {
-                val matchingMessage = ms.findStateOfUnit(Some(id)).failedMessages.headOption
-                if (!matchingMessage.isEmpty) {
-                  clusterClient.tell(SendToAll("/user/master/active", RemoveFromFailedMessages(matchingMessage)), Actor.noSender)
-                  OK
-                } else {
-                  NotFound
-                }
-              }
-              /**
-               * If we did not get a MasterState back, something is not right
-               */
-              case _ =>
-                InternalServerError
-            }.recover {
-              case e: Exception =>
-                InternalServerError
-            }
-            response
-          }
-        }
-      }
-    }
-
-  /**
-   * Forget any previous demultiplex results for the specified unit.
-   * This should make it discoverable again by the
-   * ProcessUnitWatcher and trigger a new demultiplexing job
-   */
-  @Path("/{ID}/forget")
-  @ApiOperation(
-    value = "Forget that a Processing Unit has been demultiplexed",
-    notes = "Send a message requesting that the Master will make sure that any previous demultiplexing results for a Processing Unit are forgotten. The Processing Unit will then be available for being picked up and re-demultiplexed.",
-    httpMethod = "DELETE",
-    nickname = "Forget",
-    produces = "application/json")
-  @ApiImplicitParams(Array(
-    new ApiImplicitParam(name = "ID", value = "ID of the Processing Unit to process. Typically corresponds to the name of the runfolder.", required = true, dataType = "string", paramType = "path")
-  ))
-  @ApiResponses(
-    Array(
-      new ApiResponse(
-        code = 500,
-        message = "An exception occurred"),
-      new ApiResponse(
-        code = 200,
-        message = "OK"),
-      new ApiResponse(
-        code = 400,
-        message = "Bad request")
-    ))
-  def forgetDemultiplexJob(id: String) =
-    path("forget") {
-      delete {
-        /**
-         * Complete the request asynchronously
-         */
-        detach() {
-          complete {
-            /**
-             * Request that master takes care of removing the traces of a previous demultiplexing of the corresponding Processing Unit.
-             */
-            val request = clusterClient.ask(
-              SendToAll("/user/master/active",
-                ForgetDemultiplexingProcessingUnitMessage(id)))
-            /**
-             * The request may be rejected if the Processing Unit has already started processing. In that case, return a
-             */
-            val response = request.map {
-              case Reject(reason) =>
-                BadRequest
-              case Acknowledge =>
-                OK
-              /**
-               * If we did not get a valid response back, something is not right
-               */
-              case _ =>
-                InternalServerError
-            }.recover {
-              case e: Exception =>
-                InternalServerError
-            }
-            response
-          }
-        }
-      }
-    }
-
-  /**
-   * Stop an ongoing demultiplex task on the specified unit
-   * @Path("/{ID}/stop")
-   * @ApiOperation(
-   * value = "Stop an ongoing demultiplex task on a Processing Unit",
-   * notes = "Send a message requesting that the Master will request an ongoing demultiplex task to be stopped.",
-   * httpMethod = "PUT",
-   * nickname = "Stop",
-   * produces = "application/json")
-   * @ApiImplicitParams(Array(
-   * new ApiImplicitParam(name = "ID", value = "ID of the Processing Unit to process. Typically corresponds to the name of the runfolder.", required = true, dataType = "string", paramType = "path")
-   * ))
-   * @ApiResponses(
-   * Array(
-   * new ApiResponse(
-   * code = 501,
-   * message = "Not implemented")
-   * ))
-   * def stopRunningDemultiplexJob(id: String) =
-   * path("stop") {
-   * put {
-   * detach() {
-   * /**
-   * Complete the request asynchronously
-   * */
-   * complete {
-   * /**
-   * Request that master takes care of stopping ongoing demultiplex tasks for the specified Processing Unit
-   * */
-   * clusterClient.tell(
-   * SendToAll("/user/master/active", StopDemultiplexingProcessingUnitMessage(id)),
-   * Actor.noSender)
-   * NotImplemented
-   * }
-   * }
-   * }
-   * }
-   */
-
-}
+//package hercules.api.services
+//
+//import akka.actor.{ Actor, ActorRef }
+//import akka.contrib.pattern.ClusterClient.SendToAll
+//import akka.pattern.ask
+//import akka.util.Timeout
+//
+//import com.wordnik.swagger.annotations._
+//import hercules.actors.masters.state.MasterState
+//
+//import hercules.protocols.HerculesMainProtocol._
+//import hercules.actors.masters.MasterStateProtocol
+//
+//import javax.ws.rs.Path
+//
+//import scala.concurrent.ExecutionContext
+//
+//import spray.http.StatusCodes._
+//import spray.routing._
+//
+///**
+// * The DemultiplexingService trait define operations for interacting with tasks related to demultiplexing.
+// */
+//@Api(
+//  value = "/demultiplex",
+//  description = "Control demultiplexing tasks.")
+//trait DemultiplexingService extends HerculesService {
+//
+//  implicit def ec: ExecutionContext = actorRefFactory.dispatcher
+//  implicit val clusterClient: ActorRef
+//  implicit val to: Timeout
+//  import MasterStateProtocol._
+//
+//  /**
+//   * The concatenated route for this service
+//   */
+//  def route =
+//    pathPrefix("demultiplex" / Segment) { id =>
+//      restartFailedDemultiplexJob(id) ~
+//        removeFailedDemultiplexJob(id) ~
+//        forgetDemultiplexJob(id)
+//    }
+//
+//  /**
+//   * Tell the master to restart a demultiplex job that has previously
+//   * failed and which the master has in its list of failed units
+//   */
+//  @Path("/{ID}/restart")
+//  @ApiOperation(
+//    value = "Restart a failed demultiplex task",
+//    notes = "Send a message requesting that the Master will re-queue a previously failed demultiplex task.",
+//    httpMethod = "PUT",
+//    nickname = "Restart",
+//    produces = "application/json")
+//  @ApiImplicitParams(Array(
+//    new ApiImplicitParam(name = "ID", value = "ID of the Processing Unit to process. Typically corresponds to the name of the runfolder.", required = true, dataType = "string", paramType = "path")
+//  ))
+//  @ApiResponses(
+//    Array(
+//      new ApiResponse(
+//        code = 500,
+//        message = "An exception occurred"),
+//      new ApiResponse(
+//        code = 202,
+//        message = "Accepted")
+//    ))
+//  def restartFailedDemultiplexJob(id: String) =
+//    path("restart") {
+//      put {
+//        /**
+//         * Complete the request asynchronously
+//         */
+//        detach() {
+//          complete {
+//            /**
+//             * Send a request to restart the Processing Unit corresponding to the supplied id. The response is mapped to an appropriate StatusCode.
+//             */
+//            clusterClient.ask(
+//              SendToAll(
+//                "/user/master/active",
+//                RestartDemultiplexingProcessingUnitMessage(id))
+//            ).map {
+//                case Acknowledge =>
+//                  Accepted
+//                case Reject(reason) =>
+//                  NotFound
+//                /**
+//                 * Handle exceptions that may be thrown.
+//                 */
+//              }.recover {
+//                case e: Exception =>
+//                  InternalServerError
+//              }
+//          }
+//        }
+//      }
+//    }
+//
+//  /**
+//   * Remove a failed demultiplex job from the master's list of failed demultiplex jobs.
+//   * If successful, this job will not be retried.
+//   */
+//  @Path("/{ID}/remove")
+//  @ApiOperation(
+//    value = "Remove a failed demultiplex task",
+//    notes = "Send a message requesting that the Master will remove a previously failed demultiplex task from its list of tasks.",
+//    httpMethod = "DELETE",
+//    nickname = "Remove",
+//    produces = "application/json")
+//  @ApiImplicitParams(Array(
+//    new ApiImplicitParam(name = "ID", value = "ID of the Processing Unit to process. Typically corresponds to the name of the runfolder.", required = true, dataType = "string", paramType = "path")
+//  ))
+//  @ApiResponses(
+//    Array(
+//      new ApiResponse(
+//        code = 500,
+//        message = "An exception occurred"),
+//      new ApiResponse(
+//        code = 200,
+//        message = "OK"),
+//      new ApiResponse(
+//        code = 404,
+//        message = "Not found")
+//    ))
+//  def removeFailedDemultiplexJob(id: String) =
+//    path("remove") {
+//      delete {
+//        /**
+//         * Complete the request asynchronously
+//         */
+//        detach() {
+//          complete {
+//            /**
+//             * Request the message containing the Processing Unit from master.
+//             */
+//            val request =
+//              clusterClient.ask(
+//                SendToAll(
+//                  "/user/master/active",
+//                  RequestMasterState(Some(id)))
+//              )
+//            /**
+//             * If a matching message was found, request master to remove it from its state, otherwise return a 404 status code.
+//             */
+//            val response = request.map {
+//              case ms: MasterState => {
+//                val matchingMessage = ms.findStateOfUnit(Some(id)).failedMessages.headOption
+//                if (!matchingMessage.isEmpty) {
+//                  clusterClient.tell(SendToAll("/user/master/active", RemoveFromFailedMessages(matchingMessage)), Actor.noSender)
+//                  OK
+//                } else {
+//                  NotFound
+//                }
+//              }
+//              /**
+//               * If we did not get a MasterState back, something is not right
+//               */
+//              case _ =>
+//                InternalServerError
+//            }.recover {
+//              case e: Exception =>
+//                InternalServerError
+//            }
+//            response
+//          }
+//        }
+//      }
+//    }
+//
+//  /**
+//   * Forget any previous demultiplex results for the specified unit.
+//   * This should make it discoverable again by the
+//   * ProcessUnitWatcher and trigger a new demultiplexing job
+//   */
+//  @Path("/{ID}/forget")
+//  @ApiOperation(
+//    value = "Forget that a Processing Unit has been demultiplexed",
+//    notes = "Send a message requesting that the Master will make sure that any previous demultiplexing results for a Processing Unit are forgotten. The Processing Unit will then be available for being picked up and re-demultiplexed.",
+//    httpMethod = "DELETE",
+//    nickname = "Forget",
+//    produces = "application/json")
+//  @ApiImplicitParams(Array(
+//    new ApiImplicitParam(name = "ID", value = "ID of the Processing Unit to process. Typically corresponds to the name of the runfolder.", required = true, dataType = "string", paramType = "path")
+//  ))
+//  @ApiResponses(
+//    Array(
+//      new ApiResponse(
+//        code = 500,
+//        message = "An exception occurred"),
+//      new ApiResponse(
+//        code = 200,
+//        message = "OK"),
+//      new ApiResponse(
+//        code = 400,
+//        message = "Bad request")
+//    ))
+//  def forgetDemultiplexJob(id: String) =
+//    path("forget") {
+//      delete {
+//        /**
+//         * Complete the request asynchronously
+//         */
+//        detach() {
+//          complete {
+//            /**
+//             * Request that master takes care of removing the traces of a previous demultiplexing of the corresponding Processing Unit.
+//             */
+//            val request = clusterClient.ask(
+//              SendToAll("/user/master/active",
+//                ForgetDemultiplexingProcessingUnitMessage(id)))
+//            /**
+//             * The request may be rejected if the Processing Unit has already started processing. In that case, return a
+//             */
+//            val response = request.map {
+//              case Reject(reason) =>
+//                BadRequest
+//              case Acknowledge =>
+//                OK
+//              /**
+//               * If we did not get a valid response back, something is not right
+//               */
+//              case _ =>
+//                InternalServerError
+//            }.recover {
+//              case e: Exception =>
+//                InternalServerError
+//            }
+//            response
+//          }
+//        }
+//      }
+//    }
+//
+//  /**
+//   * Stop an ongoing demultiplex task on the specified unit
+//   * @Path("/{ID}/stop")
+//   * @ApiOperation(
+//   * value = "Stop an ongoing demultiplex task on a Processing Unit",
+//   * notes = "Send a message requesting that the Master will request an ongoing demultiplex task to be stopped.",
+//   * httpMethod = "PUT",
+//   * nickname = "Stop",
+//   * produces = "application/json")
+//   * @ApiImplicitParams(Array(
+//   * new ApiImplicitParam(name = "ID", value = "ID of the Processing Unit to process. Typically corresponds to the name of the runfolder.", required = true, dataType = "string", paramType = "path")
+//   * ))
+//   * @ApiResponses(
+//   * Array(
+//   * new ApiResponse(
+//   * code = 501,
+//   * message = "Not implemented")
+//   * ))
+//   * def stopRunningDemultiplexJob(id: String) =
+//   * path("stop") {
+//   * put {
+//   * detach() {
+//   * /**
+//   * Complete the request asynchronously
+//   * */
+//   * complete {
+//   * /**
+//   * Request that master takes care of stopping ongoing demultiplex tasks for the specified Processing Unit
+//   * */
+//   * clusterClient.tell(
+//   * SendToAll("/user/master/active", StopDemultiplexingProcessingUnitMessage(id)),
+//   * Actor.noSender)
+//   * NotImplemented
+//   * }
+//   * }
+//   * }
+//   * }
+//   */
+//
+//}

--- a/src/main/scala/hercules/api/services/SwaggerService.scala
+++ b/src/main/scala/hercules/api/services/SwaggerService.scala
@@ -15,8 +15,9 @@ trait SwaggerService extends SwaggerHttpService {
    */
   override def apiTypes =
     Seq(
-      typeOf[StatusService],
-      typeOf[DemultiplexingService]
+      typeOf[StatusService]
+    // Temporarily removed. /JD 20150507
+    //typeOf[DemultiplexingService]
     )
   override def apiVersion = "2.0"
   override def baseUrl = "http://localhost:8001"

--- a/src/main/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcher.scala
+++ b/src/main/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcher.scala
@@ -77,19 +77,13 @@ class IlluminaProcessingUnitFetcher() extends ProcessingUnitFetcher {
   def searchForProcessingUnitName(
     unitName: String,
     config: IlluminaProcessingUnitFetcherConfig): Option[IlluminaProcessingUnit] = {
-    getProcessingUnits(config).find { _.name == unitName }
+    getProcessingUnits(config, filter = _ => true).find { _.name == unitName }
   }
 
   /**
    * Checks runfolders (IlluminaProcessingUnits) which are ready to be processed
    * It will delagate and return the correct sub type (MiSeq, or HiSeq) processing unit.
-   * @param runfolderRoot
-   * @param sampleSheetRoot
-   * @param customQCConfigRoot
-   * @param defaultQCConfigFile
-   * @param customProgramConfigRoot
-   * @param defaultProgramConfigFile
-   * @param log
+   * @param config
    * @return A sequence of Illumina processingUnit which are ready to be
    * processed
    */
@@ -105,13 +99,16 @@ class IlluminaProcessingUnitFetcher() extends ProcessingUnitFetcher {
   }
 
   /**
-   *  Get all available ProcessingUnits, regardless if they are ready for processing
+   *  Get all available ProcessingUnits
    *
    *  @param config
+   *  @param filter to apply to the processing - will by default exclude any
+   *                runfolders already found.
    *  @return All IlluminaProcessingUnits
    */
   private def getProcessingUnits(
-    config: IlluminaProcessingUnitFetcherConfig): Seq[IlluminaProcessingUnit] = {
+    config: IlluminaProcessingUnitFetcherConfig,
+    filter: File => Boolean = isReadyForProcessing): Seq[IlluminaProcessingUnit] = {
 
     val log = config.log
 
@@ -314,7 +311,7 @@ class IlluminaProcessingUnitFetcher() extends ProcessingUnitFetcher {
 
     for {
       runfolder <- searchForRunfolders()
-      if isReadyForProcessing(runfolder)
+      if filter(runfolder)
       samplesheet <- searchForSamplesheet(runfolder)
       qcConfig <- getQCConfig(runfolder)
       programConfig <- getProgramConfig(runfolder)

--- a/src/test/scala/hercules/api/services/DemultiplexingServiceTest.scala
+++ b/src/test/scala/hercules/api/services/DemultiplexingServiceTest.scala
@@ -1,156 +1,158 @@
-package hercules.api.services
 
-import akka.actor.ActorSystem
-import akka.contrib.pattern.ClusterClient.SendToAll
-import akka.testkit.{ TestKit, TestProbe }
-import akka.util.Timeout
-import hercules.actors.masters.MasterStateProtocol
-import hercules.actors.masters.state.MasterState
-import hercules.protocols.HerculesMainProtocol._
-import hercules.test.utils.ProcessingUnitPlaceholder
-import org.scalatest.{ BeforeAndAfterAll, FlatSpecLike, Matchers }
-import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext
-import spray.testkit.ScalatestRouteTest
-import spray.http.StatusCodes._
-import spray.routing.Directives
-import spray.http.StatusCodes
-
-class DemultiplexingServiceTest
-    extends FlatSpecLike
-    with Matchers
-    with BeforeAndAfterAll
-    with ScalatestRouteTest {
-
-  import MasterStateProtocol._
-
-  val unprocessedUnit = "unprocessedUnit"
-  val inProcessingUnitId = "testUnitInProcessing"
-  val testFailedUnitId = "testId"
-  val secondFailedUnit = "testId2"
-
-  val messagesNotYetProcessed = Set(unprocessedUnit)
-  val messagesInProcessing = Set(inProcessingUnitId)
-  val failedMessages = Set(testFailedUnitId, secondFailedUnit)
-
-  val masterState = MasterState(
-    messagesNotYetProcessed.map { (id: String) => FoundProcessingUnitMessage(ProcessingUnitPlaceholder(id)) },
-    messagesInProcessing.map { (id: String) => StartDemultiplexingProcessingUnitMessage(ProcessingUnitPlaceholder(id)) },
-    failedMessages.map { (id: String) => FailedDemultiplexingProcessingUnitMessage(ProcessingUnitPlaceholder(id), "Testing failure") }
-  )
-
-  val probe = MockBackend(
-    system = this.system,
-    masterState = masterState)
-
-  val timeout = Timeout(5.seconds)
-  val service = new DemultiplexingService {
-    def actorRefFactory = system
-    implicit val to = timeout
-    implicit val clusterClient = probe.ref
-  }
-
-  override def afterAll(): Unit = {
-    system.shutdown()
-    Thread.sleep(1000)
-  }
-
-  "A DELETE request to /demultiplex/[id]/forget" should " return an Accepted status code" in {
-    Delete(s"/demultiplex/$unprocessedUnit/forget") ~> service.route ~> check {
-      status should be(OK)
-    }
-  }
-
-  it should "trigger a ForgetDemultiplexingProcessingUnitMessage to master" in {
-    probe.expectMsg(3.seconds,
-      SendToAll(
-        "/user/master/active",
-        ForgetDemultiplexingProcessingUnitMessage(unprocessedUnit)))
-  }
-
-  // NOTE: The next two tests are dependent on a ugly hack in the mock backend which rejects
-  // messages with id testUnitInProcessing
-  it should "return a Bad Request status code if asked to forget a Processing Unit already being processed" in {
-    Delete(s"/demultiplex/$inProcessingUnitId/forget") ~> service.route ~> check {
-      status should be(BadRequest)
-    }
-  }
-
-  it should "trigger another ForgetDemultiplexingProcessingUnitMessage to master" in {
-    probe.expectMsg(3.seconds,
-      SendToAll(
-        "/user/master/active",
-        ForgetDemultiplexingProcessingUnitMessage("testUnitInProcessing")))
-  }
-
-  /*
-    "A PUT requests to /demultiplex/[id]/stop" should "return a NotImplemented status code" in {
-      Put("/demultiplex/testId/stop") ~> service.route ~> check {
-        status should be(NotImplemented)
-      }
-    }
-    it should "trigger a StopDemultiplexingProcessingUnitMessage to master" in {
-      probe.expectMsg(3.seconds,
-        SendToAll(
-          "/user/master/active",
-          StopDemultiplexingProcessingUnitMessage("testId")))
-    }
-  */
-
-  "A DELETE request to /demultiplex/[id]/remove on an existing unit" should "return a OK status code" in {
-    Delete(s"/demultiplex/$testFailedUnitId/remove") ~> service.route ~> check {
-      status should be(OK)
-    }
-  }
-  it should "trigger a RequestMasterState to master, followed by a RemoveFromFailedMessages message to master" in {
-    probe.expectMsgAllOf(5.seconds,
-      SendToAll(
-        "/user/master/active",
-        RequestMasterState(Some("testId"))),
-      SendToAll(
-        "/user/master/active",
-        RemoveFromFailedMessages(
-          Some(
-            FailedDemultiplexingProcessingUnitMessage(
-              ProcessingUnitPlaceholder(testFailedUnitId),
-              "Testing failure")))))
-  }
-
-  "A DELETE request to /demultiplex/[id]/remove on a non-existing unit" should "return a NotFound status code" in {
-    Delete("/demultiplex/testIdMissing/remove") ~> service.route ~> check {
-      status should be(NotFound)
-    }
-  }
-  it should "trigger a RequestMasterState to master, but not followed by a any more messages" in {
-    probe.expectMsg(3.seconds,
-      SendToAll(
-        "/user/master/active",
-        RequestMasterState(Some("testIdMissing"))))
-    probe.expectNoMsg(3.seconds)
-  }
-
-  "A PUT requests to /demultiplex/[id]/restart on an existing unit" should "return an ACCEPTED status code" in {
-    Put(s"/demultiplex/$secondFailedUnit/restart") ~> service.route ~> check {
-      status should be(Accepted)
-    }
-  }
-  it should "trigger a RestartDemultiplexingProcessingUnitMessage to master" in {
-    probe.expectMsg(3.seconds,
-      SendToAll(
-        "/user/master/active",
-        RestartDemultiplexingProcessingUnitMessage(secondFailedUnit)))
-  }
-
-  "A PUT requests to /demultiplex/[id]/restart on a non-existing unit" should "return an NotFound status code" in {
-    Put("/demultiplex/testIdMissing/restart") ~> service.route ~> check {
-      status should be(NotFound)
-    }
-  }
-  it should "trigger a RestartDemultiplexingProcessingUnitMessage to master" in {
-    probe.expectMsg(3.seconds,
-      SendToAll(
-        "/user/master/active",
-        RestartDemultiplexingProcessingUnitMessage("testIdMissing")))
-  }
-
-}
+// TODO Temporarily disabled. /JD 20150507
+//package hercules.api.services
+//
+//import akka.actor.ActorSystem
+//import akka.contrib.pattern.ClusterClient.SendToAll
+//import akka.testkit.{ TestKit, TestProbe }
+//import akka.util.Timeout
+//import hercules.actors.masters.MasterStateProtocol
+//import hercules.actors.masters.state.MasterState
+//import hercules.protocols.HerculesMainProtocol._
+//import hercules.test.utils.ProcessingUnitPlaceholder
+//import org.scalatest.{ BeforeAndAfterAll, FlatSpecLike, Matchers }
+//import scala.concurrent.duration._
+//import scala.concurrent.ExecutionContext
+//import spray.testkit.ScalatestRouteTest
+//import spray.http.StatusCodes._
+//import spray.routing.Directives
+//import spray.http.StatusCodes
+//
+//class DemultiplexingServiceTest
+//    extends FlatSpecLike
+//    with Matchers
+//    with BeforeAndAfterAll
+//    with ScalatestRouteTest {
+//
+//  import MasterStateProtocol._
+//
+//  val unprocessedUnit = "unprocessedUnit"
+//  val inProcessingUnitId = "testUnitInProcessing"
+//  val testFailedUnitId = "testId"
+//  val secondFailedUnit = "testId2"
+//
+//  val messagesNotYetProcessed = Set(unprocessedUnit)
+//  val messagesInProcessing = Set(inProcessingUnitId)
+//  val failedMessages = Set(testFailedUnitId, secondFailedUnit)
+//
+//  val masterState = MasterState(
+//    messagesNotYetProcessed.map { (id: String) => FoundProcessingUnitMessage(ProcessingUnitPlaceholder(id)) },
+//    messagesInProcessing.map { (id: String) => StartDemultiplexingProcessingUnitMessage(ProcessingUnitPlaceholder(id)) },
+//    failedMessages.map { (id: String) => FailedDemultiplexingProcessingUnitMessage(ProcessingUnitPlaceholder(id), "Testing failure") }
+//  )
+//
+//  val probe = MockBackend(
+//    system = this.system,
+//    masterState = masterState)
+//
+//  val timeout = Timeout(5.seconds)
+//  val service = new DemultiplexingService {
+//    def actorRefFactory = system
+//    implicit val to = timeout
+//    implicit val clusterClient = probe.ref
+//  }
+//
+//  override def afterAll(): Unit = {
+//    system.shutdown()
+//    Thread.sleep(1000)
+//  }
+//
+//  "A DELETE request to /demultiplex/[id]/forget" should " return an Accepted status code" in {
+//    Delete(s"/demultiplex/$unprocessedUnit/forget") ~> service.route ~> check {
+//      status should be(OK)
+//    }
+//  }
+//
+//  it should "trigger a ForgetDemultiplexingProcessingUnitMessage to master" in {
+//    probe.expectMsg(3.seconds,
+//      SendToAll(
+//        "/user/master/active",
+//        ForgetDemultiplexingProcessingUnitMessage(unprocessedUnit)))
+//  }
+//
+//  // NOTE: The next two tests are dependent on a ugly hack in the mock backend which rejects
+//  // messages with id testUnitInProcessing
+//  it should "return a Bad Request status code if asked to forget a Processing Unit already being processed" in {
+//    Delete(s"/demultiplex/$inProcessingUnitId/forget") ~> service.route ~> check {
+//      status should be(BadRequest)
+//    }
+//  }
+//
+//  it should "trigger another ForgetDemultiplexingProcessingUnitMessage to master" in {
+//    probe.expectMsg(3.seconds,
+//      SendToAll(
+//        "/user/master/active",
+//        ForgetDemultiplexingProcessingUnitMessage("testUnitInProcessing")))
+//  }
+//
+//  /*
+//    "A PUT requests to /demultiplex/[id]/stop" should "return a NotImplemented status code" in {
+//      Put("/demultiplex/testId/stop") ~> service.route ~> check {
+//        status should be(NotImplemented)
+//      }
+//    }
+//    it should "trigger a StopDemultiplexingProcessingUnitMessage to master" in {
+//      probe.expectMsg(3.seconds,
+//        SendToAll(
+//          "/user/master/active",
+//          StopDemultiplexingProcessingUnitMessage("testId")))
+//    }
+//  */
+//
+//  "A DELETE request to /demultiplex/[id]/remove on an existing unit" should "return a OK status code" in {
+//    Delete(s"/demultiplex/$testFailedUnitId/remove") ~> service.route ~> check {
+//      status should be(OK)
+//    }
+//  }
+//  it should "trigger a RequestMasterState to master, followed by a RemoveFromFailedMessages message to master" in {
+//    probe.expectMsgAllOf(5.seconds,
+//      SendToAll(
+//        "/user/master/active",
+//        RequestMasterState(Some("testId"))),
+//      SendToAll(
+//        "/user/master/active",
+//        RemoveFromFailedMessages(
+//          Some(
+//            FailedDemultiplexingProcessingUnitMessage(
+//              ProcessingUnitPlaceholder(testFailedUnitId),
+//              "Testing failure")))))
+//  }
+//
+//  "A DELETE request to /demultiplex/[id]/remove on a non-existing unit" should "return a NotFound status code" in {
+//    Delete("/demultiplex/testIdMissing/remove") ~> service.route ~> check {
+//      status should be(NotFound)
+//    }
+//  }
+//  it should "trigger a RequestMasterState to master, but not followed by a any more messages" in {
+//    probe.expectMsg(3.seconds,
+//      SendToAll(
+//        "/user/master/active",
+//        RequestMasterState(Some("testIdMissing"))))
+//    probe.expectNoMsg(3.seconds)
+//  }
+//
+//  "A PUT requests to /demultiplex/[id]/restart on an existing unit" should "return an ACCEPTED status code" in {
+//    Put(s"/demultiplex/$secondFailedUnit/restart") ~> service.route ~> check {
+//      status should be(Accepted)
+//    }
+//  }
+//  it should "trigger a RestartDemultiplexingProcessingUnitMessage to master" in {
+//    probe.expectMsg(3.seconds,
+//      SendToAll(
+//        "/user/master/active",
+//        RestartDemultiplexingProcessingUnitMessage(secondFailedUnit)))
+//  }
+//
+//  "A PUT requests to /demultiplex/[id]/restart on a non-existing unit" should "return an NotFound status code" in {
+//    Put("/demultiplex/testIdMissing/restart") ~> service.route ~> check {
+//      status should be(NotFound)
+//    }
+//  }
+//  it should "trigger a RestartDemultiplexingProcessingUnitMessage to master" in {
+//    probe.expectMsg(3.seconds,
+//      SendToAll(
+//        "/user/master/active",
+//        RestartDemultiplexingProcessingUnitMessage("testIdMissing")))
+//  }
+//
+//}

--- a/src/test/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcherTest.scala
+++ b/src/test/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcherTest.scala
@@ -330,4 +330,25 @@ class IlluminaProcessingUnitFetcherTest extends FlatSpec with Matchers with Befo
 
   }
 
+  it should "be able to search for runfolders by name (and find them even if they are marked as found)" in {
+
+    val createdRunfolder: Seq[IlluminaProcessingUnit] = generateExpectedRunfolders(runfolders, 1)
+    createdRunfolder.map(_.markAsFound)
+    val fetcher = new IlluminaProcessingUnitFetcher()
+
+    val result = fetcher.searchForProcessingUnitName("140806_D00457_0045_AC47TFACXX", fetcherConfig)
+
+    val expected =
+      Some(
+        HiSeqProcessingUnit(
+          IlluminaProcessingUnitConfig(
+            new File("test_samplesheets/140806_D00457_0045_AC47TFACXX_samplesheet.csv"),
+            new File("default_qc_config"),
+            Some(new File("default_program_config"))),
+          new File("test_runfolders/140806_D00457_0045_AC47TFACXX/").toURI))
+
+    assert(result === expected)
+
+  }
+
 }


### PR DESCRIPTION
This mostly contains commented out stuff, that we didn't think was ready for putting into production. We should removing it completely later, or at least moving it into a separate branch somewhere.

I also fixed a minor error in how runfolders are picked up which made it impossible to find runfolders which had already be marked as found. Higher-order-functions ftw.