### PR TITLE
Feature/pickup samplesheet from flowcell

### DIFF
--- a/src/main/scala/hercules/utils/Constants.scala
+++ b/src/main/scala/hercules/utils/Constants.scala
@@ -1,0 +1,13 @@
+package hercules.utils
+
+/**
+ * Created by johda411 on 2015-05-12.
+ * Contains constant stings.
+ */
+object Constants {
+
+  val MISEQ_CONTROL_SOFTWARE = "MiSeq Control Software"
+  val HISEQ_CONTROL_SOFTWARE = "HiSeq Control Software"
+  val HISEQ_X_CONTROL_SOFTWARE = "HiSeq X Control Software"
+
+}

--- a/src/test/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcherTest.scala
+++ b/src/test/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcherTest.scala
@@ -105,6 +105,12 @@ class IlluminaProcessingUnitFetcherTest extends FlatSpec with Matchers with Befo
 
   }
 
+  def runfolderName2FlowcellName(x: String): String =
+    if (x.contains("M00485"))
+      x.split("_")(3)
+    else
+      x.split("_")(3).drop(1) // The first letter (A or B) is not a part of the flowcell name.
+
   def createRunFolders(takeXFirst: Int = 2): Seq[File] = {
 
     defaultQCConfigFile.createNewFile()
@@ -112,7 +118,10 @@ class IlluminaProcessingUnitFetcherTest extends FlatSpec with Matchers with Befo
 
     val created = runfolders.take(takeXFirst).map(x => {
       x.mkdirs()
-      (new File(sampleSheetRoot + "/" + x.getName() + "_samplesheet.csv")).createNewFile()
+
+      val flowCellName = runfolderName2FlowcellName(x.getName)
+
+      (new File(sampleSheetRoot + "/" + flowCellName + "_samplesheet.csv")).createNewFile()
       (new File(x + "/RTAComplete.txt")).createNewFile()
       createMinimalRunParametersXml(x)
       x
@@ -127,7 +136,7 @@ class IlluminaProcessingUnitFetcherTest extends FlatSpec with Matchers with Befo
 
       val expectedConfig =
         new IlluminaProcessingUnitConfig(
-          sampleSheet = new File(sampleSheetRoot + "/" + f.getName() + "_samplesheet.csv"),
+          sampleSheet = new File(sampleSheetRoot + "/" + runfolderName2FlowcellName(f.getName()) + "_samplesheet.csv"),
           QCConfig = defaultQCConfigFile,
           programConfig = Some(defaultProgramConfigFile))
 
@@ -321,7 +330,7 @@ class IlluminaProcessingUnitFetcherTest extends FlatSpec with Matchers with Befo
       Some(
         HiSeqProcessingUnit(
           IlluminaProcessingUnitConfig(
-            new File("test_samplesheets/140806_D00457_0045_AC47TFACXX_samplesheet.csv"),
+            new File("test_samplesheets/C47TFACXX_samplesheet.csv"),
             new File("default_qc_config"),
             Some(new File("default_program_config"))),
           new File("test_runfolders/140806_D00457_0045_AC47TFACXX/").toURI))
@@ -342,7 +351,7 @@ class IlluminaProcessingUnitFetcherTest extends FlatSpec with Matchers with Befo
       Some(
         HiSeqProcessingUnit(
           IlluminaProcessingUnitConfig(
-            new File("test_samplesheets/140806_D00457_0045_AC47TFACXX_samplesheet.csv"),
+            new File("test_samplesheets/C47TFACXX_samplesheet.csv"),
             new File("default_qc_config"),
             Some(new File("default_program_config"))),
           new File("test_runfolders/140806_D00457_0045_AC47TFACXX/").toURI))

--- a/src/test/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcherTest.scala
+++ b/src/test/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcherTest.scala
@@ -360,4 +360,40 @@ class IlluminaProcessingUnitFetcherTest extends FlatSpec with Matchers with Befo
 
   }
 
+  it should "get files (samplesheet, program configs and qc configs) based on the runfolder names first, and if " +
+    "no runfolder is available, skip to using the flowcell name" in {
+
+      val runfolderNamedSampleSheet =
+        new File(sampleSheetRoot + "/140806_D00457_0045_AC47TFACXX_samplesheet.csv")
+      runfolderNamedSampleSheet.createNewFile()
+
+      val runfolderNamedProgramConfig = new File(customProgramConfigRoot + "/140806_D00457_0045_AC47TFACXX_sisyphus.yml")
+      runfolderNamedProgramConfig.createNewFile()
+
+      val runfolderNamedQCConfig = new File(customQCConfigRoot + "/140806_D00457_0045_AC47TFACXX_qc.xml")
+      runfolderNamedQCConfig.createNewFile()
+
+      val expected =
+        List(
+          HiSeqProcessingUnit(
+            IlluminaProcessingUnitConfig(
+              runfolderNamedSampleSheet,
+              runfolderNamedQCConfig,
+              Some(runfolderNamedProgramConfig)),
+            new File("test_runfolders/140806_D00457_0045_AC47TFACXX/").toURI),
+          HiSeqProcessingUnit(
+            IlluminaProcessingUnitConfig(
+              new File(sampleSheetRoot + "/C48R0ACXX_samplesheet.csv"),
+              new File("default_qc_config"),
+              Some(new File("default_program_config"))),
+            new File("test_runfolders/140806_D00457_0046_BC48R0ACXX/").toURI)
+        )
+
+      val fetcher = new IlluminaProcessingUnitFetcher()
+      val actual = fetcher.checkForReadyProcessingUnits(fetcherConfig)
+
+      assert(actual(0) === expected(0))
+
+    }
+
 }

--- a/src/test/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcherTest.scala
+++ b/src/test/scala/hercules/entities/illumina/IlluminaProcessingUnitFetcherTest.scala
@@ -392,7 +392,7 @@ class IlluminaProcessingUnitFetcherTest extends FlatSpec with Matchers with Befo
       val fetcher = new IlluminaProcessingUnitFetcher()
       val actual = fetcher.checkForReadyProcessingUnits(fetcherConfig)
 
-      assert(actual(0) === expected(0))
+      assert(actual.sortBy(x => x.name) === expected.sortBy(x => x.name))
 
     }
 


### PR DESCRIPTION
This PR adds functionality to check for samplesheet, program configs and qc configs either by the runfolder name, or by the flowcell id. The first is preferred, but if now matching file is found we fall back to the latter.